### PR TITLE
Adding in ferriod-army that saturates a single CPU

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ferroid-army"
+version = "0.1.3"
+dependencies = [
+ "criterion",
+ "ferroid",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "ferroid"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "base32",
  "criterion",
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "ferroid-army"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "criterion",
  "crossbeam-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crunchy"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,6 +196,7 @@ name = "ferroid-army"
 version = "0.1.3"
 dependencies = [
  "criterion",
+ "crossbeam-channel",
  "ferroid",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [workspace]
 resolver = "3"
 members = [
-    "crates/ferroid"
+    "crates/ferroid",
+    "crates/ferroid-army"
 ]
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Nick Angelou <angelou.nick@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ futures = { version = "0.3", default-features = false }
 derive_more = { version = "2.0", default-features = false }
 serde = { version = "1.0", default-features = false }
 base32 = { version = "0.5", default-features = false }
+crossbeam-channel = { version = "0.5", default-features = false }

--- a/crates/ferroid-army/Cargo.toml
+++ b/crates/ferroid-army/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "ferroid-army"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+readme.workspace = true
+description.workspace = true
+repository.workspace = true
+documentation.workspace = true
+keywords.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+
+[lib]
+
+[dependencies]
+tracing = { workspace = true, optional = true, features = ["attributes"] }
+ferroid = { path = "../ferroid" }
+
+[dev-dependencies]
+criterion = { workspace = true }
+
+[[bench]]
+name = "bench"
+harness = false
+
+[features]
+default = []
+tracing = ["dep:tracing", "ferroid/tracing"]
+serde = ["ferroid/serde"]
+base32 = ["ferroid/base32"]

--- a/crates/ferroid-army/Cargo.toml
+++ b/crates/ferroid-army/Cargo.toml
@@ -17,6 +17,7 @@ all-features = true
 
 [dependencies]
 tracing = { workspace = true, optional = true, features = ["attributes"] }
+crossbeam-channel = { workspace = true, features = ["std"] }
 ferroid = { path = "../ferroid" }
 
 [dev-dependencies]

--- a/crates/ferroid-army/benches/bench.rs
+++ b/crates/ferroid-army/benches/bench.rs
@@ -1,0 +1,56 @@
+use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
+use ferroid::{
+    BasicSnowflakeGenerator, MonotonicClock, Snowflake, SnowflakeGenerator, SnowflakeTwitterId,
+};
+use ferroid_army::Army;
+use std::time::Instant;
+
+// Total number of IDs to generate per benchmark iteration
+const TOTAL_IDS: usize = 4096 * 256; // Enough to simulate at least 256 Pending cycles
+
+/// Benchmark a `SingleArmy` with the specified number of generators
+fn bench_single_army<ID, G>(c: &mut Criterion, group_name: &str, generator_fn: impl Fn(u64) -> G)
+where
+    ID: Snowflake,
+    G: SnowflakeGenerator<ID>,
+{
+    let mut group = c.benchmark_group(group_name);
+
+    for num_generators in [1, 2, 4, 8, 16, 32, 64, 128] {
+        group.throughput(Throughput::Elements(TOTAL_IDS as u64));
+        group.bench_function(
+            format!("elems/{}/generators/{}", TOTAL_IDS, num_generators),
+            |b| {
+                b.iter_custom(|iters| {
+                    let start = Instant::now();
+
+                    for _ in 0..iters {
+                        let mut army = Army::new(
+                            (0..num_generators)
+                                .map(|machine_id| generator_fn(machine_id))
+                                .collect(),
+                        );
+
+                        for _ in 0..TOTAL_IDS {
+                            black_box(army.next_id());
+                        }
+                    }
+
+                    start.elapsed()
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Run benchmark with various generator counts
+fn benchmark_mono_sequential_army_basic(c: &mut Criterion) {
+    bench_single_army::<SnowflakeTwitterId, _>(c, "mono/sequential/army/basic", |machine_id| {
+        BasicSnowflakeGenerator::new(machine_id, MonotonicClock::default())
+    })
+}
+
+criterion_group!(benches, benchmark_mono_sequential_army_basic,);
+criterion_main!(benches);

--- a/crates/ferroid-army/benches/bench.rs
+++ b/crates/ferroid-army/benches/bench.rs
@@ -1,6 +1,7 @@
 use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
 use ferroid::{
     BasicSnowflakeGenerator, MonotonicClock, Snowflake, SnowflakeGenerator, SnowflakeTwitterId,
+    TimeSource,
 };
 use ferroid_army::Army;
 use std::time::Instant;
@@ -9,14 +10,15 @@ use std::time::Instant;
 const TOTAL_IDS: usize = 4096 * 256; // Enough to simulate at least 256 Pending cycles
 
 /// Benchmark a `SingleArmy` with the specified number of generators
-fn bench_single_army<ID, G>(c: &mut Criterion, group_name: &str, generator_fn: impl Fn(u64) -> G)
+fn bench_single_army<G, ID, T>(c: &mut Criterion, group_name: &str, generator_fn: impl Fn(u64) -> G)
 where
+    G: SnowflakeGenerator<ID, T>,
     ID: Snowflake,
-    G: SnowflakeGenerator<ID>,
+    T: TimeSource<ID::Ty>,
 {
     let mut group = c.benchmark_group(group_name);
 
-    for num_generators in [1, 2, 4, 8, 16, 32, 64, 128] {
+    for num_generators in [1, 2, 4, 8, 16, 32, 64] {
         group.throughput(Throughput::Elements(TOTAL_IDS as u64));
         group.bench_function(
             format!("elems/{}/generators/{}", TOTAL_IDS, num_generators),
@@ -25,11 +27,10 @@ where
                     let start = Instant::now();
 
                     for _ in 0..iters {
-                        let mut army = Army::new(
-                            (0..num_generators)
-                                .map(|machine_id| generator_fn(machine_id))
-                                .collect(),
-                        );
+                        let generators: Vec<_> = (0..num_generators)
+                            .map(|machine_id| generator_fn(machine_id))
+                            .collect();
+                        let mut army = Army::new(generators);
 
                         for _ in 0..TOTAL_IDS {
                             black_box(army.next_id());
@@ -47,10 +48,10 @@ where
 
 /// Run benchmark with various generator counts
 fn benchmark_mono_sequential_army_basic(c: &mut Criterion) {
-    bench_single_army::<SnowflakeTwitterId, _>(c, "mono/sequential/army/basic", |machine_id| {
+    bench_single_army::<_, SnowflakeTwitterId, _>(c, "mono/sequential/army/basic", |machine_id| {
         BasicSnowflakeGenerator::new(machine_id, MonotonicClock::default())
     })
 }
 
-criterion_group!(benches, benchmark_mono_sequential_army_basic,);
+criterion_group!(benches, benchmark_mono_sequential_army_basic);
 criterion_main!(benches);

--- a/crates/ferroid-army/src/army.rs
+++ b/crates/ferroid-army/src/army.rs
@@ -1,30 +1,33 @@
-use ferroid::{IdGenStatus, Result, Snowflake, SnowflakeGenerator};
+use ferroid::{IdGenStatus, Result, Snowflake, SnowflakeGenerator, TimeSource};
 use std::collections::VecDeque;
 use std::marker::PhantomData;
 
-pub struct Army<G, ID>
+pub struct Army<G, ID, T>
 where
-    G: SnowflakeGenerator<ID>,
+    G: SnowflakeGenerator<ID, T>,
     ID: Snowflake,
+    T: TimeSource<ID::Ty>,
 {
     generators: Vec<G>,
     ready: VecDeque<usize>,
     pending: VecDeque<usize>,
     _id: PhantomData<ID>,
+    _t: PhantomData<T>,
 }
 
-impl<G, ID> Army<G, ID>
+impl<G, ID, T> Army<G, ID, T>
 where
-    G: SnowflakeGenerator<ID>,
+    G: SnowflakeGenerator<ID, T>,
     ID: Snowflake,
+    T: TimeSource<ID::Ty>,
 {
     pub fn new(generators: Vec<G>) -> Self {
-        let ready = (0..generators.len()).collect();
         Self {
+            ready: (0..generators.len()).collect(),
             generators,
-            ready,
             pending: VecDeque::new(),
             _id: PhantomData,
+            _t: PhantomData,
         }
     }
 

--- a/crates/ferroid-army/src/army.rs
+++ b/crates/ferroid-army/src/army.rs
@@ -1,0 +1,63 @@
+use ferroid::{IdGenStatus, Result, Snowflake, SnowflakeGenerator};
+use std::collections::VecDeque;
+use std::marker::PhantomData;
+
+pub struct Army<G, ID>
+where
+    G: SnowflakeGenerator<ID>,
+    ID: Snowflake,
+{
+    generators: Vec<G>,
+    ready: VecDeque<usize>,
+    pending: VecDeque<usize>,
+    _id: PhantomData<ID>,
+}
+
+impl<G, ID> Army<G, ID>
+where
+    G: SnowflakeGenerator<ID>,
+    ID: Snowflake,
+{
+    pub fn new(generators: Vec<G>) -> Self {
+        let ready = (0..generators.len()).collect();
+        Self {
+            generators,
+            ready,
+            pending: VecDeque::new(),
+            _id: PhantomData,
+        }
+    }
+
+    pub fn next_id(&mut self) -> ID {
+        self.try_next_id().unwrap()
+    }
+
+    pub fn try_next_id(&mut self) -> Result<ID> {
+        loop {
+            let len = self.ready.len();
+
+            for _ in 0..len {
+                let idx = self
+                    .ready
+                    .pop_front()
+                    .expect("ready queue empty during poll");
+
+                match self.generators[idx].try_next() {
+                    Ok(IdGenStatus::Ready { id }) => {
+                        self.ready.push_back(idx);
+                        return Ok(id);
+                    }
+                    Ok(IdGenStatus::Pending { .. }) => {
+                        self.pending.push_back(idx);
+                    }
+                    Err(e) => {
+                        self.pending.push_back(idx);
+                        return Err(e);
+                    }
+                }
+            }
+
+            std::mem::swap(&mut self.ready, &mut self.pending);
+        }
+    }
+}

--- a/crates/ferroid-army/src/lib.rs
+++ b/crates/ferroid-army/src/lib.rs
@@ -1,0 +1,3 @@
+mod army;
+
+pub use army::*;

--- a/crates/ferroid/src/generator/basic.rs
+++ b/crates/ferroid/src/generator/basic.rs
@@ -23,19 +23,19 @@ use tracing::instrument;
 ///
 /// [`LockSnowflakeGenerator`]: crate::LockSnowflakeGenerator
 /// [`AtomicSnowflakeGenerator`]: crate::AtomicSnowflakeGenerator
-pub struct BasicSnowflakeGenerator<T, ID>
+pub struct BasicSnowflakeGenerator<ID, T>
 where
-    T: TimeSource<ID::Ty>,
     ID: Snowflake,
+    T: TimeSource<ID::Ty>,
 {
     state: ID,
     time: T,
 }
 
-impl<T, ID> BasicSnowflakeGenerator<T, ID>
+impl<ID, T> BasicSnowflakeGenerator<ID, T>
 where
-    T: TimeSource<ID::Ty>,
     ID: Snowflake,
+    T: TimeSource<ID::Ty>,
 {
     /// Creates a new [`BasicSnowflakeGenerator`] initialized with the current
     /// time and a given machine ID.
@@ -62,7 +62,7 @@ where
     /// ```
     /// use ferroid::{BasicSnowflakeGenerator, SnowflakeTwitterId, MonotonicClock};
     ///
-    /// let mut generator = BasicSnowflakeGenerator::<_, SnowflakeTwitterId>::new(0, MonotonicClock::default());
+    /// let mut generator = BasicSnowflakeGenerator::<SnowflakeTwitterId, _>::new(0, MonotonicClock::default());
     /// let id = generator.next_id();
     /// ```
     ///
@@ -121,7 +121,7 @@ where
     ///
     /// // Create a clock and a generator with machine_id = 0
     /// let clock = MonotonicClock::default();
-    /// let mut generator = BasicSnowflakeGenerator::<_, SnowflakeTwitterId>::new(0, clock);
+    /// let mut generator = BasicSnowflakeGenerator::<SnowflakeTwitterId, _>::new(0, clock);
     ///
     /// // Attempt to generate a new ID
     /// match generator.next_id() {
@@ -159,7 +159,7 @@ where
     ///
     /// // Create a clock and a generator with machine_id = 0
     /// let clock = MonotonicClock::default();
-    /// let mut generator = BasicSnowflakeGenerator::<_, SnowflakeTwitterId>::new(0, clock);
+    /// let mut generator = BasicSnowflakeGenerator::<SnowflakeTwitterId, _>::new(0, clock);
     ///
     /// // Attempt to generate a new ID
     /// match generator.try_next_id() {

--- a/crates/ferroid/src/generator/interface.rs
+++ b/crates/ferroid/src/generator/interface.rs
@@ -13,7 +13,14 @@ use crate::{
 /// # Note
 /// This trait is not intended for external use and may change or be removed in
 /// future versions.
-pub trait SnowflakeGenerator<ID: Snowflake> {
+pub trait SnowflakeGenerator<ID, T>
+where
+    ID: Snowflake,
+    T: TimeSource<ID::Ty>,
+{
+    // Creates a new generator
+    fn new(machine_id: ID::Ty, clock: T) -> Self;
+
     /// Returns the next available ID or yields if generation is temporarily
     /// stalled.
     fn next(&mut self) -> IdGenStatus<ID>;
@@ -31,7 +38,14 @@ pub trait SnowflakeGenerator<ID: Snowflake> {
 /// # Note
 /// This trait is not intended for external use and may change or be removed in
 /// future versions.
-pub trait MultithreadedSnowflakeGenerator<ID: Snowflake> {
+pub trait MultithreadedSnowflakeGenerator<ID, T>
+where
+    ID: Snowflake,
+    T: TimeSource<ID::Ty>,
+{
+    // Creates a new generator
+    fn new(machine_id: ID::Ty, clock: T) -> Self;
+
     /// Returns the next available ID or yields if generation is temporarily
     /// stalled.
     fn next(&self) -> IdGenStatus<ID>;
@@ -40,11 +54,15 @@ pub trait MultithreadedSnowflakeGenerator<ID: Snowflake> {
     fn try_next(&self) -> Result<IdGenStatus<ID>>;
 }
 
-impl<T, ID> SnowflakeGenerator<ID> for BasicSnowflakeGenerator<T, ID>
+impl<ID, T> SnowflakeGenerator<ID, T> for BasicSnowflakeGenerator<ID, T>
 where
-    T: TimeSource<ID::Ty>,
     ID: Snowflake,
+    T: TimeSource<ID::Ty>,
 {
+    fn new(machine_id: ID::Ty, clock: T) -> Self {
+        Self::new(machine_id, clock)
+    }
+
     fn next(&mut self) -> IdGenStatus<ID> {
         self.next_id()
     }
@@ -54,11 +72,14 @@ where
     }
 }
 
-impl<T, ID> SnowflakeGenerator<ID> for LockSnowflakeGenerator<T, ID>
+impl<T, ID> SnowflakeGenerator<ID, T> for LockSnowflakeGenerator<ID, T>
 where
-    T: TimeSource<ID::Ty>,
     ID: Snowflake,
+    T: TimeSource<ID::Ty>,
 {
+    fn new(machine_id: ID::Ty, clock: T) -> Self {
+        Self::new(machine_id, clock)
+    }
     fn next(&mut self) -> IdGenStatus<ID> {
         self.next_id()
     }
@@ -68,11 +89,15 @@ where
     }
 }
 
-impl<T, ID> SnowflakeGenerator<ID> for AtomicSnowflakeGenerator<T, ID>
+impl<ID, T> SnowflakeGenerator<ID, T> for AtomicSnowflakeGenerator<ID, T>
 where
-    T: TimeSource<u64>,
     ID: Snowflake<Ty = u64>,
+    T: TimeSource<u64>,
 {
+    fn new(machine_id: ID::Ty, clock: T) -> Self {
+        Self::new(machine_id, clock)
+    }
+
     fn next(&mut self) -> IdGenStatus<ID> {
         self.next_id()
     }
@@ -82,11 +107,15 @@ where
     }
 }
 
-impl<T, ID> MultithreadedSnowflakeGenerator<ID> for LockSnowflakeGenerator<T, ID>
+impl<T, ID> MultithreadedSnowflakeGenerator<ID, T> for LockSnowflakeGenerator<ID, T>
 where
-    T: TimeSource<ID::Ty>,
     ID: Snowflake,
+    T: TimeSource<ID::Ty>,
 {
+    fn new(machine_id: ID::Ty, clock: T) -> Self {
+        Self::new(machine_id, clock)
+    }
+
     fn next(&self) -> IdGenStatus<ID> {
         self.next_id()
     }
@@ -96,11 +125,15 @@ where
     }
 }
 
-impl<T, ID> MultithreadedSnowflakeGenerator<ID> for AtomicSnowflakeGenerator<T, ID>
+impl<T, ID> MultithreadedSnowflakeGenerator<ID, T> for AtomicSnowflakeGenerator<ID, T>
 where
-    T: TimeSource<u64>,
     ID: Snowflake<Ty = u64>,
+    T: TimeSource<u64>,
 {
+    fn new(machine_id: ID::Ty, clock: T) -> Self {
+        Self::new(machine_id, clock)
+    }
+
     fn next(&self) -> IdGenStatus<ID> {
         self.next_id()
     }

--- a/crates/ferroid/src/generator/lock.rs
+++ b/crates/ferroid/src/generator/lock.rs
@@ -27,19 +27,19 @@ use tracing::instrument;
 ///
 /// [`BasicSnowflakeGenerator`]: crate::BasicSnowflakeGenerator
 /// [`AtomicSnowflakeGenerator`]: crate::AtomicSnowflakeGenerator
-pub struct LockSnowflakeGenerator<T, ID>
+pub struct LockSnowflakeGenerator<ID, T>
 where
-    T: TimeSource<ID::Ty>,
     ID: Snowflake,
+    T: TimeSource<ID::Ty>,
 {
     state: Arc<Mutex<ID>>,
     time: T,
 }
 
-impl<T, ID> LockSnowflakeGenerator<T, ID>
+impl<ID, T> LockSnowflakeGenerator<ID, T>
 where
-    T: TimeSource<ID::Ty>,
     ID: Snowflake,
+    T: TimeSource<ID::Ty>,
 {
     /// Creates a new [`LockSnowflakeGenerator`] initialized with the current
     /// time and a given machine ID.
@@ -66,7 +66,7 @@ where
     /// ```
     /// use ferroid::{LockSnowflakeGenerator, SnowflakeTwitterId, MonotonicClock};
     ///
-    /// let generator = LockSnowflakeGenerator::<_, SnowflakeTwitterId>::new(0, MonotonicClock::default());
+    /// let generator = LockSnowflakeGenerator::<SnowflakeTwitterId, _>::new(0, MonotonicClock::default());
     /// let id = generator.next_id();
     /// ```
     ///
@@ -124,7 +124,7 @@ where
     ///
     /// // Create a clock and a generator with machine_id = 0
     /// let clock = MonotonicClock::default();
-    /// let mut generator = LockSnowflakeGenerator::<_, SnowflakeTwitterId>::new(0, clock);
+    /// let mut generator = LockSnowflakeGenerator::<SnowflakeTwitterId, _>::new(0, clock);
     ///
     /// // Attempt to generate a new ID
     /// match generator.next_id() {
@@ -162,7 +162,7 @@ where
     ///
     /// // Create a clock and a generator with machine_id = 0
     /// let clock = MonotonicClock::default();
-    /// let mut generator = LockSnowflakeGenerator::<_, SnowflakeTwitterId>::new(0, clock);
+    /// let mut generator = LockSnowflakeGenerator::<SnowflakeTwitterId, _>::new(0, clock);
     ///
     /// // Attempt to generate a new ID
     /// match generator.try_next_id() {

--- a/crates/ferroid/src/generator/tests.rs
+++ b/crates/ferroid/src/generator/tests.rs
@@ -6,8 +6,8 @@ use crate::{
     },
 };
 use core::fmt;
-use std::cell::Cell;
 use std::rc::Rc;
+use std::{cell::Cell, hash::Hash};
 
 struct MockTime {
     millis: u64,
@@ -19,57 +19,69 @@ impl TimeSource<u64> for MockTime {
     }
 }
 
-fn run_id_sequence_increments_within_same_tick<G>(mut generator: G)
+fn run_id_sequence_increments_within_same_tick<G, ID, T>(mut generator: G)
 where
-    G: SnowflakeGenerator<SnowflakeTwitterId>,
+    G: SnowflakeGenerator<ID, T>,
+    ID: Snowflake + fmt::Debug + fmt::Display,
+    ID::Ty: fmt::Debug + fmt::Display,
+    T: TimeSource<ID::Ty>,
 {
     let id1 = generator.next().unwrap_ready();
     let id2 = generator.next().unwrap_ready();
     let id3 = generator.next().unwrap_ready();
 
-    assert_eq!(id1.timestamp(), 42);
-    assert_eq!(id2.timestamp(), 42);
-    assert_eq!(id3.timestamp(), 42);
-    assert_eq!(id1.sequence(), 0);
-    assert_eq!(id2.sequence(), 1);
-    assert_eq!(id3.sequence(), 2);
+    assert_eq!(id1.timestamp(), 42_u64.into());
+    assert_eq!(id2.timestamp(), 42_u64.into());
+    assert_eq!(id3.timestamp(), 42_u64.into());
+    assert_eq!(id1.sequence(), 0_u64.into());
+    assert_eq!(id2.sequence(), 1_u64.into());
+    assert_eq!(id3.sequence(), 2_u64.into());
     assert!(id1 < id2 && id2 < id3);
 }
 
-fn run_generator_returns_pending_when_sequence_exhausted<G>(mut generator: G)
+fn run_generator_returns_pending_when_sequence_exhausted<G, ID, T>(mut generator: G)
 where
-    G: SnowflakeGenerator<SnowflakeTwitterId>,
+    G: SnowflakeGenerator<ID, T>,
+    ID: Snowflake + fmt::Debug + fmt::Display,
+    ID::Ty: fmt::Debug + fmt::Display,
+    T: TimeSource<ID::Ty>,
 {
     let yield_until = generator.next().unwrap_pending();
-    assert_eq!(yield_until, 1);
+    assert_eq!(yield_until, ID::ONE);
 }
 
-fn run_generator_handles_rollover<G>(mut generator: G, shared_time: Rc<MockStepTime>)
+fn run_generator_handles_rollover<G, ID, T>(mut generator: G, shared_time: SharedMockStepTime)
 where
-    G: SnowflakeGenerator<SnowflakeTwitterId>,
+    G: SnowflakeGenerator<ID, T>,
+    ID: Snowflake + fmt::Debug + fmt::Display,
+    ID::Ty: fmt::Debug + fmt::Display,
+    T: TimeSource<ID::Ty>,
 {
-    for i in 0..=SnowflakeTwitterId::max_sequence() {
+    for i in 0..=ID::max_sequence().into() {
         let id = generator.next().unwrap_ready();
-        assert_eq!(id.sequence(), i);
-        assert_eq!(id.timestamp(), 42);
+        assert_eq!(id.sequence(), i.into());
+        assert_eq!(id.timestamp(), 42_u64.into());
     }
 
     let yield_until = generator.next().unwrap_pending();
-    assert_eq!(yield_until, 43);
+    assert_eq!(yield_until, 43_u64.into());
 
-    shared_time.index.set(1);
+    shared_time.clock.index.set(1);
 
     let id = generator.next().unwrap_ready();
-    assert_eq!(id.timestamp(), 43);
-    assert_eq!(id.sequence(), 0);
+    assert_eq!(id.timestamp(), 43_u64.into());
+    assert_eq!(id.sequence(), 0_u64.into());
 }
 
-fn run_generator_monotonic<G>(mut generator: G)
+fn run_generator_monotonic<G, ID, T>(mut generator: G)
 where
-    G: SnowflakeGenerator<SnowflakeTwitterId>,
+    G: SnowflakeGenerator<ID, T>,
+    ID: Snowflake + fmt::Debug,
+    ID::Ty: fmt::Debug,
+    T: TimeSource<ID::Ty>,
 {
-    let mut last_timestamp = 0;
-    let mut sequence = 0;
+    let mut last_timestamp = ID::ZERO;
+    let mut sequence = ID::ZERO;
 
     for _ in 0..8192 {
         loop {
@@ -77,15 +89,15 @@ where
                 IdGenStatus::Ready { id } => {
                     let ts = id.timestamp();
                     if ts > last_timestamp {
-                        sequence = 0;
+                        sequence = ID::ZERO;
                     }
 
                     assert!(ts >= last_timestamp);
-                    assert_eq!(id.machine_id(), 1);
+                    assert_eq!(id.machine_id(), ID::ONE);
                     assert_eq!(id.sequence(), sequence);
 
                     last_timestamp = ts;
-                    sequence += 1;
+                    sequence += ID::ONE;
                     break;
                 }
                 IdGenStatus::Pending { .. } => {
@@ -96,9 +108,11 @@ where
     }
 }
 
-fn run_generator_monotonic_threaded<G>(make_generator: impl Fn() -> G)
+fn run_generator_monotonic_threaded<G, ID, T>(make_generator: impl Fn() -> G)
 where
-    G: MultithreadedSnowflakeGenerator<SnowflakeTwitterId> + Sync + Send,
+    G: MultithreadedSnowflakeGenerator<ID, T> + Send + Sync,
+    ID: Snowflake + PartialEq + Eq + Hash + Send + Sync,
+    T: TimeSource<ID::Ty>,
 {
     use std::collections::HashSet;
     use std::sync::{Arc, Mutex};
@@ -137,150 +151,165 @@ where
     assert_eq!(final_count, TOTAL_IDS, "Expected {} unique IDs", TOTAL_IDS);
 }
 
+#[derive(Clone)]
+struct SharedMockStepTime {
+    clock: Rc<MockStepTime>,
+}
+
+impl TimeSource<u64> for SharedMockStepTime {
+    fn current_millis(&self) -> u64 {
+        self.clock.values[self.clock.index.get()]
+    }
+}
 struct MockStepTime {
     values: Vec<u64>,
     index: Cell<usize>,
 }
 
-impl TimeSource<u64> for Rc<MockStepTime> {
+struct FixedTime;
+impl TimeSource<u64> for FixedTime {
     fn current_millis(&self) -> u64 {
-        self.values[self.index.get()]
+        0
     }
 }
 
 #[test]
 fn basic_generator_sequence_test() {
     let mock_time = MockTime { millis: 42 };
-    let generator = BasicSnowflakeGenerator::new(0, mock_time);
+    let generator: BasicSnowflakeGenerator<SnowflakeTwitterId, _> =
+        BasicSnowflakeGenerator::new(0, mock_time);
     run_id_sequence_increments_within_same_tick(generator);
 }
 
 #[test]
 fn lock_generator_sequence_test() {
     let mock_time = MockTime { millis: 42 };
-    let generator = LockSnowflakeGenerator::new(0, mock_time);
+    let generator: LockSnowflakeGenerator<SnowflakeTwitterId, _> =
+        LockSnowflakeGenerator::new(0, mock_time);
     run_id_sequence_increments_within_same_tick(generator);
 }
 
 #[test]
 fn atomic_generator_sequence_test() {
     let mock_time = MockTime { millis: 42 };
-    let generator = AtomicSnowflakeGenerator::new(0, mock_time);
+    let generator: AtomicSnowflakeGenerator<SnowflakeTwitterId, _> =
+        AtomicSnowflakeGenerator::new(0, mock_time);
     run_id_sequence_increments_within_same_tick(generator);
 }
 
 #[test]
 fn basic_generator_pending_test() {
-    struct FixedTime;
-    impl TimeSource<u64> for FixedTime {
-        fn current_millis(&self) -> u64 {
-            0
-        }
-    }
-    let generator = BasicSnowflakeGenerator::from_components(
-        0,
-        0,
-        SnowflakeTwitterId::max_sequence(),
-        FixedTime,
-    );
+    let generator: BasicSnowflakeGenerator<SnowflakeTwitterId, _> =
+        BasicSnowflakeGenerator::from_components(
+            0,
+            0,
+            SnowflakeTwitterId::max_sequence(),
+            FixedTime,
+        );
     run_generator_returns_pending_when_sequence_exhausted(generator);
 }
 
 #[test]
 fn lock_generator_pending_test() {
-    struct FixedTime;
-    impl TimeSource<u64> for FixedTime {
-        fn current_millis(&self) -> u64 {
-            0
-        }
-    }
-    let generator = LockSnowflakeGenerator::from_components(
-        0,
-        0,
-        SnowflakeTwitterId::max_sequence(),
-        FixedTime,
-    );
+    let generator: LockSnowflakeGenerator<SnowflakeTwitterId, _> =
+        LockSnowflakeGenerator::from_components(
+            0,
+            0,
+            SnowflakeTwitterId::max_sequence(),
+            FixedTime,
+        );
     run_generator_returns_pending_when_sequence_exhausted(generator);
 }
 
 #[test]
 fn atomic_generator_pending_test() {
-    struct FixedTime;
-    impl TimeSource<u64> for FixedTime {
-        fn current_millis(&self) -> u64 {
-            0
-        }
-    }
-    let generator = AtomicSnowflakeGenerator::from_components(
-        0,
-        0,
-        SnowflakeTwitterId::max_sequence(),
-        FixedTime,
-    );
+    let generator: AtomicSnowflakeGenerator<SnowflakeTwitterId, _> =
+        AtomicSnowflakeGenerator::from_components(
+            0,
+            0,
+            SnowflakeTwitterId::max_sequence(),
+            FixedTime,
+        );
     run_generator_returns_pending_when_sequence_exhausted(generator);
 }
 
 #[test]
 fn basic_generator_rollover_test() {
-    let shared_time = Rc::new(MockStepTime {
-        values: vec![42, 43],
-        index: Cell::new(0),
-    });
-    let generator = BasicSnowflakeGenerator::new(1, shared_time.clone());
+    let shared_time = SharedMockStepTime {
+        clock: Rc::new(MockStepTime {
+            values: vec![42, 43],
+            index: Cell::new(0),
+        }),
+    };
+    let generator: BasicSnowflakeGenerator<SnowflakeTwitterId, _> =
+        BasicSnowflakeGenerator::new(1, shared_time.clone());
     run_generator_handles_rollover(generator, shared_time);
 }
 
 #[test]
 fn lock_generator_rollover_test() {
-    let shared_time = Rc::new(MockStepTime {
-        values: vec![42, 43],
-        index: Cell::new(0),
-    });
-    let generator = LockSnowflakeGenerator::new(1, shared_time.clone());
+    let shared_time = SharedMockStepTime {
+        clock: Rc::new(MockStepTime {
+            values: vec![42, 43],
+            index: Cell::new(0),
+        }),
+    };
+    let generator: LockSnowflakeGenerator<SnowflakeTwitterId, _> =
+        LockSnowflakeGenerator::new(1, shared_time.clone());
     run_generator_handles_rollover(generator, shared_time);
 }
 
 #[test]
 fn atomic_generator_rollover_test() {
-    let shared_time = Rc::new(MockStepTime {
-        values: vec![42, 43],
-        index: Cell::new(0),
-    });
-    let generator = AtomicSnowflakeGenerator::new(1, shared_time.clone());
+    let shared_time = SharedMockStepTime {
+        clock: Rc::new(MockStepTime {
+            values: vec![42, 43],
+            index: Cell::new(0),
+        }),
+    };
+    let generator: AtomicSnowflakeGenerator<SnowflakeTwitterId, _> =
+        AtomicSnowflakeGenerator::new(1, shared_time.clone());
     run_generator_handles_rollover(generator, shared_time);
 }
 
 #[test]
 fn basic_generator_monotonic_clock_sequence_increments() {
     let clock = MonotonicClock::default();
-    let generator = BasicSnowflakeGenerator::new(1, clock);
+    let generator: BasicSnowflakeGenerator<SnowflakeTwitterId, _> =
+        BasicSnowflakeGenerator::new(1, clock);
     run_generator_monotonic(generator);
 }
 
 #[test]
 fn lock_generator_monotonic_clock_sequence_increments() {
     let clock = MonotonicClock::default();
-    let generator = LockSnowflakeGenerator::new(1, clock);
+    let generator: LockSnowflakeGenerator<SnowflakeTwitterId, _> =
+        LockSnowflakeGenerator::new(1, clock);
     run_generator_monotonic(generator);
 }
 
 #[test]
 fn atomic_generator_monotonic_clock_sequence_increments() {
     let clock = MonotonicClock::default();
-    let generator = AtomicSnowflakeGenerator::new(1, clock);
+    let generator: AtomicSnowflakeGenerator<SnowflakeTwitterId, _> =
+        AtomicSnowflakeGenerator::new(1, clock);
     run_generator_monotonic(generator);
 }
 
 #[test]
 fn lock_generator_threaded_monotonic() {
     let clock = MonotonicClock::default();
-    run_generator_monotonic_threaded(move || LockSnowflakeGenerator::new(0, clock));
+    run_generator_monotonic_threaded(move || {
+        LockSnowflakeGenerator::<SnowflakeTwitterId, _>::new(0, clock)
+    });
 }
 
 #[test]
 fn atomic_generator_threaded_monotonic() {
     let clock = MonotonicClock::default();
-    run_generator_monotonic_threaded(move || AtomicSnowflakeGenerator::new(0, clock));
+    run_generator_monotonic_threaded(move || {
+        AtomicSnowflakeGenerator::<SnowflakeTwitterId, _>::new(0, clock)
+    });
 }
 
 trait IdGenStatusExt<T>

--- a/crates/ferroid/src/id.rs
+++ b/crates/ferroid/src/id.rs
@@ -1,5 +1,8 @@
 use core::fmt;
-use std::ops::Add;
+use std::{
+    hash::Hash,
+    ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign},
+};
 
 /// A trait representing a layout-compatible Snowflake ID generator.
 ///
@@ -18,9 +21,29 @@ use std::ops::Add;
 /// assert_eq!(id.machine_id(), 2);
 /// assert_eq!(id.sequence(), 1);
 /// ```
-pub trait Snowflake: Sized + Copy + fmt::Display {
+pub trait Snowflake:
+    Sized + Copy + Clone + fmt::Display + PartialOrd + Ord + PartialEq + Eq + Hash
+{
     /// Scalar type for all bit fields (typically `u64`)
-    type Ty: Ord + Copy + Add<Output = Self::Ty> + Into<Self::Ty> + From<Self::Ty>;
+    type Ty: Ord
+        + Copy
+        + Add<Output = Self::Ty>
+        + AddAssign
+        + Sub<Output = Self::Ty>
+        + SubAssign
+        + Mul<Output = Self::Ty>
+        + MulAssign
+        + Div<Output = Self::Ty>
+        + DivAssign
+        + Into<Self::Ty>
+        + Into<u64>
+        + From<Self::Ty>
+        + From<u8>
+        + From<u16>
+        + From<u32>
+        + From<u64>
+        + fmt::Debug
+        + fmt::Display;
 
     /// Zero value (used for resetting the sequence)
     const ZERO: Self::Ty;

--- a/crates/ferroid/src/status.rs
+++ b/crates/ferroid/src/status.rs
@@ -22,7 +22,7 @@ use crate::Snowflake;
 ///     }
 /// }
 ///
-/// let mut generator = BasicSnowflakeGenerator::<_, SnowflakeTwitterId>::from_components(0, 1, SnowflakeTwitterId::max_sequence(), FixedTime);
+/// let mut generator = BasicSnowflakeGenerator::<SnowflakeTwitterId, _>::from_components(0, 1, SnowflakeTwitterId::max_sequence(), FixedTime);
 /// match generator.next_id() {
 ///     IdGenStatus::Ready { id } => println!("ID: {}", id.timestamp()),
 ///     IdGenStatus::Pending { yield_until } => println!("Back off until: {yield_until}"),


### PR DESCRIPTION
Adding in a cooperative scheduler that switches between different generators to saturate the CPU.

- Minor changes in the order of generics
- The atomic generator now yields on CAS failures to give control to the user (useful for advanced use-cases)