### PR TITLE
Move trait bounds and remove Self trait bound

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,7 +394,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferroid"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "base32",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Nick Angelou <angelou.nick@gmail.com>"]
@@ -25,4 +25,4 @@ futures = { version = "0.3", default-features = false }
 pin-project-lite = { version = "0.2", default-features = false }
 tokio = { version = "1.45", default-features = false }
 smol = { version = "2.0", default-features = false }
-num_cpus = { version = "1.16", default-feautres = false }
+num_cpus = { version = "1.16", default-features = false }

--- a/crates/ferroid/src/futures.rs
+++ b/crates/ferroid/src/futures.rs
@@ -16,7 +16,11 @@ use std::{
 ///
 /// The default implementation uses [`GeneratorFuture`] and a specified
 /// [`SleepProvider`] to yield when the generator is not yet ready.
-pub trait SnowflakeGeneratorAsyncExt<ID, T> {
+pub trait SnowflakeGeneratorAsyncExt<ID, T>
+where
+    ID: Snowflake,
+    T: TimeSource<ID::Ty>,
+{
     /// Returns a future that resolves to the next available Snowflake ID.
     ///
     /// If the generator is not ready to issue a new ID immediately, the future
@@ -27,9 +31,6 @@ pub trait SnowflakeGeneratorAsyncExt<ID, T> {
     /// This future may return an error if the generator encounters one.
     fn try_next_id_async<S>(&self) -> impl Future<Output = Result<ID>>
     where
-        Self: SnowflakeGenerator<ID, T>,
-        ID: Snowflake,
-        T: TimeSource<ID::Ty>,
         S: SleepProvider;
 }
 
@@ -41,8 +42,6 @@ where
 {
     fn try_next_id_async<'a, S>(&'a self) -> impl Future<Output = Result<ID>>
     where
-        ID: Snowflake,
-        T: TimeSource<ID::Ty>,
         S: SleepProvider,
     {
         GeneratorFuture::<'a, G, ID, T, S>::new(self)

--- a/crates/ferroid/src/runtime/smol.rs
+++ b/crates/ferroid/src/runtime/smol.rs
@@ -12,7 +12,11 @@ use std::{
 /// This trait provides a convenience method for using a [`SleepProvider`]
 /// backed by the `smol` runtime, allowing you to call `.try_next_id_async()`
 /// without needing to specify the sleep strategy manually.
-pub trait SnowflakeGeneratorAsyncSmolExt<ID, T> {
+pub trait SnowflakeGeneratorAsyncSmolExt<ID, T>
+where
+    ID: Snowflake,
+    T: TimeSource<ID::Ty>,
+{
     /// Returns a future that resolves to the next available Snowflake ID using
     /// the [`SmolSleep`] provider.
     ///
@@ -26,11 +30,7 @@ pub trait SnowflakeGeneratorAsyncSmolExt<ID, T> {
     ///
     /// [`SnowflakeGeneratorAsyncExt::try_next_id_async`]:
     ///     crate::SnowflakeGeneratorAsyncExt::try_next_id_async
-    fn try_next_id_async(&self) -> impl Future<Output = Result<ID>>
-    where
-        Self: SnowflakeGenerator<ID, T>,
-        ID: Snowflake,
-        T: TimeSource<ID::Ty>;
+    fn try_next_id_async(&self) -> impl Future<Output = Result<ID>>;
 }
 
 impl<G, ID, T> SnowflakeGeneratorAsyncSmolExt<ID, T> for G

--- a/crates/ferroid/src/runtime/tokio.rs
+++ b/crates/ferroid/src/runtime/tokio.rs
@@ -6,7 +6,11 @@ use crate::{Result, SleepProvider, Snowflake, SnowflakeGenerator, TimeSource};
 /// This trait provides a convenience method for using a [`SleepProvider`]
 /// backed by the `tokio` runtime, allowing you to call `.try_next_id_async()`
 /// without specifying the sleep strategy manually.
-pub trait SnowflakeGeneratorAsyncTokioExt<ID, T> {
+pub trait SnowflakeGeneratorAsyncTokioExt<ID, T>
+where
+    ID: Snowflake,
+    T: TimeSource<ID::Ty>,
+{
     /// Returns a future that resolves to the next available Snowflake ID using
     /// the [`TokioSleep`] provider.
     ///
@@ -20,11 +24,7 @@ pub trait SnowflakeGeneratorAsyncTokioExt<ID, T> {
     ///
     /// [`SnowflakeGeneratorAsyncExt::try_next_id_async`]:
     ///     crate::SnowflakeGeneratorAsyncExt::try_next_id_async
-    fn try_next_id_async(&self) -> impl Future<Output = Result<ID>>
-    where
-        Self: SnowflakeGenerator<ID, T>,
-        ID: Snowflake,
-        T: TimeSource<ID::Ty>;
+    fn try_next_id_async(&self) -> impl Future<Output = Result<ID>>;
 }
 
 impl<G, ID, T> SnowflakeGeneratorAsyncTokioExt<ID, T> for G


### PR DESCRIPTION
Moves the trait bounds from the AsyncExt trait method to the trait itself while removing the unnecessary restriction on Self.