### PR TITLE
Add define_snowflake_id! Macro System

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
+checksum = "1237c0ae75a0f3765f58910ff9cdd0a12eeb39ab2f4c7de23262f337f0aacbb3"
 dependencies = [
  "async-lock",
  "cfg-if",
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
+checksum = "cde3f4e40e6021d7acffc90095cbd6dc54cb593903d1de5832f435eb274b85dc"
 dependencies = [
  "async-channel",
  "async-io",
@@ -137,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "async-signal"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
+checksum = "d7605a4e50d4b06df3898d5a70bf5fde51ed9059b0434b73105193bc27acce0d"
 dependencies = [
  "async-io",
  "async-lock",
@@ -252,18 +252,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.38"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
+checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.38"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
+checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -394,7 +394,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferroid"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "base32",
  "criterion",
@@ -506,9 +506,9 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
 
 [[package]]
 name = "itertools"
@@ -542,9 +542,9 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "memchr"
@@ -626,13 +626,13 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.7.4"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
+checksum = "b53a684391ad002dd6a596ceb6c74fd004fdce75f4be2e3f615068abbea5fd50"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.4.0",
+ "hermit-abi 0.5.1",
  "pin-project-lite",
  "rustix",
  "tracing",
@@ -694,9 +694,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags",
  "errno",
@@ -810,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.0"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Nick Angelou <angelou.nick@gmail.com>"]
@@ -16,13 +16,13 @@ documentation = "https://docs.rs/ferroid"
 keywords = ["id", "snowflake", "ulid", "uuid", "monotonic"]
 
 [workspace.dependencies]
-tracing = { version = "0.1", default-features = false }
+base32 = { version = "0.5", default-features = false }
 criterion = { version = "0.6", default-features = false }
 derive_more = { version = "2.0", default-features = false }
-serde = { version = "1.0", default-features = false }
-base32 = { version = "0.5", default-features = false }
 futures = { version = "0.3", default-features = false }
-pin-project-lite = { version = "0.2", default-features = false }
-tokio = { version = "1.45", default-features = false }
-smol = { version = "2.0", default-features = false }
 num_cpus = { version = "1.16", default-features = false }
+pin-project-lite = { version = "0.2", default-features = false }
+serde = { version = "1.0", default-features = false }
+smol = { version = "2.0", default-features = false }
+tokio = { version = "1.45", default-features = false }
+tracing = { version = "0.1", default-features = false }

--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ let id: SnowflakeTwitterId = loop {
 };
 
 println!("Generated ID: {}", id);
-println!("Timestamp: {}, Machine ID: {}, Sequence: {}", id.timestamp(), id.machine_id(), id.sequence());
 ```
 
 #### Asynchronous

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ let id: SnowflakeTwitterId = loop {
 };
 
 println!("Generated ID: {}", id);
+println!("Timestamp: {}, Machine ID: {}, Sequence: {}", id.timestamp(), id.machine_id(), id.sequence());
 ```
 
 #### Asynchronous

--- a/README.md
+++ b/README.md
@@ -16,10 +16,8 @@ Features:
 - 📐 Customizable layouts via the `Snowflake` trait
 - 🔢 Lexicographically sortable string encoding
 
-[![Crates.io][crates-badge]][crates-url]
-[![MIT licensed][mit-badge]][mit-url]
-[![Apache 2.0 licensed][apache-badge]][apache-url]
-[![CI][ci-badge]][ci-url]
+[![Crates.io][crates-badge]][crates-url] [![MIT licensed][mit-badge]][mit-url]
+[![Apache 2.0 licensed][apache-badge]][apache-url] [![CI][ci-badge]][ci-url]
 
 [crates-badge]: https://img.shields.io/crates/v/ferroid.svg
 [crates-url]: https://crates.io/crates/ferroid
@@ -137,26 +135,28 @@ fn main() -> Result<()> {
 
 ### Custom Layouts
 
-To define a custom Snowflake layout, implement `Snowflake`:
+To define a custom Snowflake layout, use the `define_snowflake_id` macro:
 
 ```rust
-use core::fmt;
-use ferroid::Snowflake;
+use ferroid::define_snowflake_id;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-struct MyCustomId {
-    id: u64,
-}
+// A Twitter-like ID
+define_snowflake_id!(
+    MyCustomId, u64,
+    reserved: 1,
+    timestamp: 41,
+    machine_id: 10,
+    sequence: 12
+);
 
-impl Snowflake for MyCustomId {
-    // ...
-}
-
-impl fmt::Display for MyCustomId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.id)
-    }
-}
+// Or a 128-bit ID
+define_snowflake_id!(
+    MyCustomLongId, u128,
+    reserved: 40,
+    timestamp: 48,
+    machine_id: 20,
+    sequence: 20
+);
 ```
 
 ### Behavior

--- a/crates/ferroid/Cargo.toml
+++ b/crates/ferroid/Cargo.toml
@@ -17,18 +17,20 @@ all-features = true
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-tracing = { workspace = true, optional = true, features = ["attributes"] }
-derive_more = { workspace = true, features = ["from"] }
-serde = { workspace = true, optional = true, features = ["derive"] }
 base32 = { workspace = true, optional = true }
-futures = { workspace = true, optional = true, features = ["alloc"] }
+derive_more = { workspace = true, features = ["from"] }
+futures = { workspace = true, optional = true }
 pin-project-lite = { workspace = true, optional = true }
-tokio = { workspace = true, optional = true, features = ["time", "rt-multi-thread", "macros"] }
+serde = { workspace = true, optional = true, features = ["derive"] }
 smol = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true, features = ["time", "rt-multi-thread"] }
+tracing = { workspace = true, optional = true, features = ["attributes"] }
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio", "async_smol"] }
+futures = { workspace = true,  features = ["alloc"] }
 num_cpus = { workspace = true }
+tokio = { workspace = true, features = ["macros"] }
 
 [[bench]]
 name = "bench"

--- a/crates/ferroid/src/id.rs
+++ b/crates/ferroid/src/id.rs
@@ -273,12 +273,22 @@ impl fmt::Display for SnowflakeTwitterId {
 }
 
 impl fmt::Debug for SnowflakeTwitterId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let name = std::any::type_name::<Self>()
-            .rsplit("::")
-            .next()
-            .unwrap_or("Unknown");
-        write_bit_layout_debug(f, self, name)
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let full = std::any::type_name::<Self>();
+        let name = full.rsplit("::").next().unwrap_or(full);
+
+        if f.alternate() {
+            // Pretty-print with layout visualization
+            write_bit_layout_debug(f, self, name)
+        } else {
+            // Compact debug fallback
+            f.debug_struct(name)
+                .field("id", &self.id())
+                .field("timestamp", &self.timestamp())
+                .field("machine_id", &self.machine_id())
+                .field("sequence", &self.sequence())
+                .finish()
+        }
     }
 }
 
@@ -410,12 +420,22 @@ impl fmt::Display for SnowflakeDiscordId {
 }
 
 impl fmt::Debug for SnowflakeDiscordId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let name = std::any::type_name::<Self>()
-            .rsplit("::")
-            .next()
-            .unwrap_or("Unknown");
-        write_bit_layout_debug(f, self, name)
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let full = std::any::type_name::<Self>();
+        let name = full.rsplit("::").next().unwrap_or(full);
+
+        if f.alternate() {
+            // Pretty-print with layout visualization
+            write_bit_layout_debug(f, self, name)
+        } else {
+            // Compact debug fallback
+            f.debug_struct(name)
+                .field("id", &self.id())
+                .field("timestamp", &self.timestamp())
+                .field("machine_id", &self.machine_id())
+                .field("sequence", &self.sequence())
+                .finish()
+        }
     }
 }
 
@@ -532,12 +552,22 @@ impl fmt::Display for SnowflakeMastodonId {
 }
 
 impl fmt::Debug for SnowflakeMastodonId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let name = std::any::type_name::<Self>()
-            .rsplit("::")
-            .next()
-            .unwrap_or("Unknown");
-        write_bit_layout_debug(f, self, name)
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let full = std::any::type_name::<Self>();
+        let name = full.rsplit("::").next().unwrap_or(full);
+
+        if f.alternate() {
+            // Pretty-print with layout visualization
+            write_bit_layout_debug(f, self, name)
+        } else {
+            // Compact debug fallback
+            f.debug_struct(name)
+                .field("id", &self.id())
+                .field("timestamp", &self.timestamp())
+                .field("machine_id", &self.machine_id())
+                .field("sequence", &self.sequence())
+                .finish()
+        }
     }
 }
 
@@ -677,12 +707,22 @@ impl fmt::Display for SnowflakeInstagramId {
 }
 
 impl fmt::Debug for SnowflakeInstagramId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let name = std::any::type_name::<Self>()
-            .rsplit("::")
-            .next()
-            .unwrap_or("Unknown");
-        write_bit_layout_debug(f, self, name)
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let full = std::any::type_name::<Self>();
+        let name = full.rsplit("::").next().unwrap_or(full);
+
+        if f.alternate() {
+            // Pretty-print with layout visualization
+            write_bit_layout_debug(f, self, name)
+        } else {
+            // Compact debug fallback
+            f.debug_struct(name)
+                .field("id", &self.id())
+                .field("timestamp", &self.timestamp())
+                .field("machine_id", &self.machine_id())
+                .field("sequence", &self.sequence())
+                .finish()
+        }
     }
 }
 
@@ -824,49 +864,70 @@ impl fmt::Display for SnowflakeLongId {
 }
 
 impl fmt::Debug for SnowflakeLongId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct(std::any::type_name::<Self>())
-            .field("id", &self.id)
-            .field("timestamp", &self.timestamp())
-            .field("machine_id", &self.machine_id())
-            .field("sequence", &self.sequence())
-            .finish()
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let full = std::any::type_name::<Self>();
+        let name = full.rsplit("::").next().unwrap_or(full);
+
+        if f.alternate() {
+            // Pretty-print with layout visualization
+            write_bit_layout_debug(f, self, name)
+        } else {
+            // Compact debug fallback
+            f.debug_struct(name)
+                .field("id", &self.id())
+                .field("timestamp", &self.timestamp())
+                .field("machine_id", &self.machine_id())
+                .field("sequence", &self.sequence())
+                .finish()
+        }
     }
 }
 
-pub struct FieldLayout {
-    pub name: &'static str,
-    pub bits: u8,
-    pub value: u64,
+/// Represents a concrete bit field value for layout rendering.
+#[derive(Debug, Clone)]
+struct FieldLayout<T> {
+    name: &'static str,
+    bits: u8,
+    value: T,
 }
 
-pub trait SnowflakeBitLayout {
-    fn id(&self) -> u64;
-    fn fields(&self) -> Vec<FieldLayout>;
+/// Trait used to support debug table rendering of bit fields.
+trait SnowflakeBitLayout {
+    type Ty: fmt::LowerHex + fmt::Display + ToString + Copy;
+
+    fn id(&self) -> Self::Ty;
+    fn fields(&self) -> Vec<FieldLayout<Self::Ty>>;
     fn to_padded_string(&self) -> String;
+
     #[cfg(feature = "base32")]
     fn encode(&self) -> String;
 }
 
-pub fn write_bit_layout_debug(
+fn write_bit_layout_debug<L>(
     f: &mut fmt::Formatter<'_>,
-    id_type: &impl SnowflakeBitLayout,
+    id_type: &L,
     type_name: &str,
-) -> fmt::Result {
+) -> fmt::Result
+where
+    L: SnowflakeBitLayout,
+{
     let visible_fields: Vec<_> = id_type
         .fields()
         .into_iter()
         .filter(|field| field.bits > 0)
         .collect();
 
-    // Compute max width per column: label, dec, hex
     let columns: Vec<usize> = visible_fields
         .iter()
         .map(|field| {
             let label_len = format!("{} ({})", field.name, field.bits).len();
             let dec_len = field.value.to_string().len();
             let hex_len = format!("0x{:x}", field.value).len();
-            *[label_len, dec_len, hex_len].iter().max().unwrap() + 2 // +2 for padding
+            [label_len, dec_len, hex_len]
+                .into_iter()
+                .max()
+                .unwrap_or_default()
+                + 2
         })
         .collect();
 
@@ -885,56 +946,50 @@ pub fn write_bit_layout_debug(
     writeln!(f, "{} {{", type_name)?;
     writeln!(
         f,
-        "    raw id     : 0x{:016x} ({})",
+        "    raw id     : 0x{:x} ({})",
         id_type.id(),
         id_type.id()
     )?;
     writeln!(f, "    padded     : {}", id_type.to_padded_string())?;
 
     #[cfg(feature = "base32")]
-    {
-        writeln!(f, "    base32     : {}", id_type.encode())?;
-    }
+    writeln!(f, "    base32     : {}", id_type.encode())?;
 
     writeln!(f, "    layout     :")?;
-
-    // Top border
     write!(f, "        +")?;
     for &w in &columns {
         write!(f, "{}+", "-".repeat(w))?;
     }
     writeln!(f)?;
 
-    // Field labels
     write!(f, "        |")?;
     for (field, &w) in visible_fields.iter().zip(&columns) {
-        let label = format!("{} ({})", field.name, field.bits);
-        write!(f, "{}|", center(label, w))?;
+        write!(
+            f,
+            "{}|",
+            center(format!("{} ({})", field.name, field.bits), w)
+        )?;
     }
     writeln!(f)?;
 
-    // Mid border
     write!(f, "        +")?;
     for &w in &columns {
         write!(f, "{}+", "-".repeat(w))?;
     }
     writeln!(f)?;
 
-    // Decimal values
     write!(f, "        |")?;
     for (field, &w) in visible_fields.iter().zip(&columns) {
         write!(f, "{}|", center(field.value, w))?;
     }
     writeln!(f)?;
 
-    // Hex values
     write!(f, "        |")?;
     for (field, &w) in visible_fields.iter().zip(&columns) {
         write!(f, "{}|", center(format!("0x{:x}", field.value), w))?;
     }
     writeln!(f)?;
 
-    // Bottom border
     write!(f, "        +")?;
     for &w in &columns {
         write!(f, "{}+", "-".repeat(w))?;
@@ -945,11 +1000,13 @@ pub fn write_bit_layout_debug(
 }
 
 impl SnowflakeBitLayout for SnowflakeTwitterId {
-    fn id(&self) -> u64 {
+    type Ty = u64;
+
+    fn id(&self) -> Self::Ty {
         self.id
     }
 
-    fn fields(&self) -> Vec<FieldLayout> {
+    fn fields(&self) -> Vec<FieldLayout<Self::Ty>> {
         vec![
             FieldLayout {
                 name: "reserved",
@@ -986,11 +1043,13 @@ impl SnowflakeBitLayout for SnowflakeTwitterId {
 }
 
 impl SnowflakeBitLayout for SnowflakeDiscordId {
-    fn id(&self) -> u64 {
+    type Ty = u64;
+
+    fn id(&self) -> Self::Ty {
         self.id
     }
 
-    fn fields(&self) -> Vec<FieldLayout> {
+    fn fields(&self) -> Vec<FieldLayout<Self::Ty>> {
         vec![
             FieldLayout {
                 name: "timestamp",
@@ -1022,11 +1081,13 @@ impl SnowflakeBitLayout for SnowflakeDiscordId {
 }
 
 impl SnowflakeBitLayout for SnowflakeMastodonId {
-    fn id(&self) -> u64 {
+    type Ty = u64;
+
+    fn id(&self) -> Self::Ty {
         self.id
     }
 
-    fn fields(&self) -> Vec<FieldLayout> {
+    fn fields(&self) -> Vec<FieldLayout<Self::Ty>> {
         vec![
             FieldLayout {
                 name: "timestamp",
@@ -1053,11 +1114,13 @@ impl SnowflakeBitLayout for SnowflakeMastodonId {
 }
 
 impl SnowflakeBitLayout for SnowflakeInstagramId {
-    fn id(&self) -> u64 {
+    type Ty = u64;
+
+    fn id(&self) -> Self::Ty {
         self.id
     }
 
-    fn fields(&self) -> Vec<FieldLayout> {
+    fn fields(&self) -> Vec<FieldLayout<Self::Ty>> {
         vec![
             FieldLayout {
                 name: "timestamp",
@@ -1088,6 +1151,49 @@ impl SnowflakeBitLayout for SnowflakeInstagramId {
     }
 }
 
+impl SnowflakeBitLayout for SnowflakeLongId {
+    type Ty = u128;
+
+    fn id(&self) -> Self::Ty {
+        self.id
+    }
+
+    fn fields(&self) -> Vec<FieldLayout<Self::Ty>> {
+        vec![
+            FieldLayout {
+                name: "reserved",
+                bits: 40,
+                value: 0,
+            },
+            FieldLayout {
+                name: "timestamp",
+                bits: 48,
+                value: self.timestamp(),
+            },
+            FieldLayout {
+                name: "machine_id",
+                bits: 20,
+                value: self.machine_id(),
+            },
+            FieldLayout {
+                name: "sequence",
+                bits: 20,
+                value: self.sequence(),
+            },
+        ]
+    }
+
+    #[cfg(feature = "base32")]
+    fn encode(&self) -> String {
+        use crate::SnowflakeBase32Ext;
+        <Self as SnowflakeBase32Ext>::encode(self)
+    }
+
+    fn to_padded_string(&self) -> String {
+        self.to_padded_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1099,7 +1205,7 @@ mod tests {
         let seq = SnowflakeTwitterId::max_sequence();
 
         let id = SnowflakeTwitterId::from(ts, mid, seq);
-        println!("ID: {:?}", id);
+        println!("ID: {:#?}", id);
         assert_eq!(id.timestamp(), ts);
         assert_eq!(id.machine_id(), mid);
         assert_eq!(id.sequence(), seq);
@@ -1113,7 +1219,7 @@ mod tests {
         let seq = SnowflakeDiscordId::max_sequence();
 
         let id = SnowflakeDiscordId::from(ts, mid, seq);
-        println!("ID: {:?}", id);
+        println!("ID: {:#?}", id);
         assert_eq!(id.timestamp(), ts);
         assert_eq!(id.machine_id(), mid);
         assert_eq!(id.sequence(), seq);
@@ -1126,7 +1232,7 @@ mod tests {
         let seq = SnowflakeMastodonId::max_sequence();
 
         let id = SnowflakeMastodonId::from(ts, seq);
-        println!("ID: {:?}", id);
+        println!("ID: {:#?}", id);
         assert_eq!(id.timestamp(), ts);
         assert_eq!(id.machine_id(), 0); // no machine_id
         assert_eq!(id.sequence(), seq);
@@ -1140,7 +1246,7 @@ mod tests {
         let seq = SnowflakeInstagramId::max_sequence();
 
         let id = SnowflakeInstagramId::from(ts, mid, seq);
-        println!("ID: {:?}", id);
+        println!("ID: {:#?}", id);
         assert_eq!(id.timestamp(), ts);
         assert_eq!(id.machine_id(), mid);
         assert_eq!(id.sequence(), seq);
@@ -1154,7 +1260,7 @@ mod tests {
         let seq = SnowflakeLongId::max_sequence();
 
         let id = SnowflakeLongId::from(ts, mid, seq);
-
+        println!("ID: {:#?}", id);
         assert_eq!(id.timestamp(), ts);
         assert_eq!(id.machine_id(), mid);
         assert_eq!(id.sequence(), seq);

--- a/crates/ferroid/src/id.rs
+++ b/crates/ferroid/src/id.rs
@@ -150,16 +150,25 @@ pub trait Snowflake:
 /// and `sequence`.
 ///
 /// These components are always laid out from **most significant bit (MSB)** to
-/// **least significant bit (LSB)** — in that exact order.
+/// **least significant bit (LSB)** - in that exact order.
 ///
 /// - The first field (`reserved`) occupies the highest bits.
 /// - The last field (`sequence`) occupies the lowest bits.
 /// - The total number of bits **must exactly equal** the size of the backing
-///   integer type (`u64`, `u128`, etc.). If it doesn’t, the macro will trigger
+///   integer type (`u64`, `u128`, etc.). If it doesn't, the macro will trigger
 ///   a compile-time assertion failure.
 ///
-/// ## Example: Twitter-like Layout
+/// ```text
+/// define_snowflake_id!(
+///     <TypeName>, <IntegerType>,
+///     reserved: <bits>,
+///     timestamp: <bits>,
+///     machine_id: <bits>,
+///     sequence: <bits>
+/// );
+///```
 ///
+/// ## Example: A Twitter-like layout
 /// ```rust
 /// use ferroid::{define_snowflake_id, Snowflake};
 ///

--- a/crates/ferroid/src/id.rs
+++ b/crates/ferroid/src/id.rs
@@ -170,7 +170,7 @@ pub trait Snowflake:
 ///
 /// ## Example: A Twitter-like layout
 /// ```rust
-/// use ferroid::{define_snowflake_id, Snowflake};
+/// use ferroid::define_snowflake_id;
 ///
 /// define_snowflake_id!(
 ///     MyCustomId, u64,
@@ -321,6 +321,8 @@ macro_rules! define_snowflake_id {
                 let name = full.rsplit("::").next().unwrap_or(full);
                 let mut dbg = f.debug_struct(name);
                 dbg.field("id", &format_args!("{:} (0x{:x})", self.to_raw(), self.to_raw()));
+
+                use $crate::Snowflake;
                 dbg.field("padded", &self.to_padded_string());
 
                 #[cfg(feature = "base32")]

--- a/crates/ferroid/src/mono_clock_native.rs
+++ b/crates/ferroid/src/mono_clock_native.rs
@@ -48,7 +48,7 @@ impl MonotonicClock {
     /// monotonic timer (`Instant`) to measure elapsed time since startup.
     ///
     /// On each call to [`current_millis`], the clock returns the current tick
-    /// value plus a fixed offset — the precomputed difference between the
+    /// value plus a fixed offset - the precomputed difference between the
     /// current wall-clock time (`SystemTime::now()`) and the given epoch.
     ///
     /// This design avoids syscalls on the hot path and ensures that time never

--- a/crates/ferroid/src/runtime/tokio.rs
+++ b/crates/ferroid/src/runtime/tokio.rs
@@ -38,7 +38,7 @@ where
     }
 }
 
-/// An implementation of [`SleepProvider`] using Tokio’s timer.
+/// An implementation of [`SleepProvider`] using Tokio's timer.
 ///
 /// This is the default provider for use in async applications built on Tokio.
 pub struct TokioSleep;


### PR DESCRIPTION
Add `define_snowflake_id!` Macro System for composable layouts!

## Macro Syntax Overview
The define_snowflake_id! macro defines a newtype wrapper around an integer (e.g. u64, u128) using a declarative field layout. The syntax is:

```rust
define_snowflake_id!(
    <TypeName>, <IntegerType>,
    reserved: <bits>,
    timestamp: <bits>,
    machine_id: <bits>,
    sequence: <bits>
);
```

Ex:

```rust
define_snowflake_id!(
    MyCustomId, u64,
    reserved: 1,
    timestamp: 41,
    machine_id: 10,
    sequence: 12
);
```
This will automatically implement the following traits:
- `Snowflake`
- `SnowflakeBase32Ext` (if the feature is enabled)
- `fmt::Display` and `fmt::Debug`

## Caveats
- You must specify all four sections (in that order), even if some have 0 bits.
- The total bit width **must exactly match** the bit width of the backing integer (u64 -> 64 bits). Enforced at compile time.


