### PR TITLE
Add `SmolYield` and `TokioYield` strategies to `SleepProvider` for cooperative task yielding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,7 +374,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferroid"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "base32",
  "criterion",
@@ -479,12 +479,6 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
-name = "hermit-abi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
@@ -551,11 +545,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 
@@ -611,7 +605,7 @@ checksum = "b53a684391ad002dd6a596ceb6c74fd004fdce75f4be2e3f615068abbea5fd50"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.5.1",
+ "hermit-abi",
  "pin-project-lite",
  "rustix",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.5"
+version = "0.3.6"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Nick Angelou <angelou.nick@gmail.com>"]
@@ -19,7 +19,7 @@ keywords = ["id", "snowflake", "ulid", "uuid", "monotonic"]
 base32 = { version = "0.5", default-features = false }
 criterion = { version = "0.6", default-features = false }
 futures = { version = "0.3", default-features = false }
-num_cpus = { version = "1.16", default-features = false }
+num_cpus = { version = "1.17", default-features = false }
 pin-project-lite = { version = "0.2", default-features = false }
 serde = { version = "1.0", default-features = false }
 smol = { version = "2.0", default-features = false }

--- a/crates/ferroid/benches/bench.rs
+++ b/crates/ferroid/benches/bench.rs
@@ -10,7 +10,7 @@ use futures::future::try_join_all;
 use smol::Task;
 use std::{
     sync::{Arc, Barrier},
-    thread::{scope, yield_now},
+    thread::scope,
     time::Instant,
 };
 use tokio::runtime::Builder;
@@ -194,7 +194,9 @@ fn bench_generator_contended_yield<G, ID, T>(
                                                     black_box(id);
                                                     break;
                                                 }
-                                                IdGenStatus::Pending { .. } => yield_now(),
+                                                IdGenStatus::Pending { .. } => {
+                                                    std::thread::yield_now()
+                                                }
                                             }
                                         }
                                     }

--- a/crates/ferroid/src/error.rs
+++ b/crates/ferroid/src/error.rs
@@ -3,7 +3,7 @@ use std::sync::{MutexGuard, PoisonError};
 
 pub type Result<T> = core::result::Result<T, Error>;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 #[non_exhaustive]
 pub enum Error {
     LockPoisoned,

--- a/crates/ferroid/src/futures.rs
+++ b/crates/ferroid/src/futures.rs
@@ -54,7 +54,8 @@ where
 /// This allows the generator to be generic over runtimes like `Tokio` or
 /// `Smol`.
 pub trait SleepProvider {
-    type Sleep: Future<Output = ()>;
+    /// We require `Send` so that the future can be safely moved across threads
+    type Sleep: Future<Output = ()> + Send;
 
     fn sleep_for(dur: Duration) -> Self::Sleep;
 }

--- a/crates/ferroid/src/id.rs
+++ b/crates/ferroid/src/id.rs
@@ -8,8 +8,8 @@ use core::{
 /// Trait for converting numeric-like values into a `u64`.
 ///
 /// This is typically used to normalize custom duration types into milliseconds
-/// for compatibility with APIs like [`core::time::Duration::from_millis`], which
-/// are commonly required in async sleep contexts such as
+/// for compatibility with APIs like [`core::time::Duration::from_millis`],
+/// which are commonly required in async sleep contexts such as
 /// [`tokio::time::sleep`].
 pub trait ToU64 {
     fn to_u64(self) -> Result<u64>;
@@ -250,6 +250,21 @@ macro_rules! define_snowflake_id {
             pub const fn sequence(&self) -> $int {
                 (self.id >> Self::SEQUENCE_SHIFT) & Self::SEQUENCE_MASK
             }
+            /// Returns the maximum representable timestamp value based on
+            /// Self::TIMESTAMP_BITS.
+            pub const fn max_timestamp() -> $int {
+                (1 << Self::TIMESTAMP_BITS) - 1
+            }
+            /// Returns the maximum representable machine ID value based on
+            /// Self::MACHINE_ID_BITS.
+            pub const fn max_machine_id() -> $int {
+                (1 << Self::MACHINE_ID_BITS) - 1
+            }
+            /// Returns the maximum representable sequence value based on
+            /// Self::SEQUENCE_BITS.
+            pub const fn max_sequence() -> $int {
+                (1 << Self::SEQUENCE_BITS) - 1
+            }
         }
 
         impl $crate::Snowflake for $name {
@@ -302,7 +317,7 @@ macro_rules! define_snowflake_id {
                 let mut n = max;
                 let mut digits = 1;
                 while n >= 10 {
-                    n = n / 10;
+                    n /= 10;
                     digits += 1;
                 }
                 format!("{:0width$}", self.to_raw(), width = digits)


### PR DESCRIPTION
This PR introduces two new implementations of the SleepProvider trait:

`TokioYield`: Uses t`okio::task::yield_now()` to cooperatively yield to the scheduler. This approach avoids timer overhead and is more responsive in low-concurrency scenarios. However, it may cause increased scheduler churn under high load due to immediate rescheduling.

`SmolYield`: Uses `smol::future::yield_now()` for the same purpose within Smol-based runtimes. Offers similar trade-offs.

These yield-based strategies are ideal for scenarios where the generator is likely to become ready shortly and the cost of registering timers outweighs the benefits. The default ext trait continues to use the `TokioSleep` and `SmolSleep` implementations because they generally reduce unnecessary polling and CPU usage under high, concurrent load.

### Motivation
Enables pluggable runtime behavior for async ID generation loops that rely on cooperative scheduling instead of timer-based delays. This is useful in environments where sleep resolution is coarse- such as Windows- or where Tokio's minimum sleep granularity (typically 1ms) introduces unnecessary latency. Yielding can improve responsiveness in low-latency workloads where tasks become ready quickly and timers are too blunt an instrument.

### Other
- Added more `const fn` to retrieve information on the underlying type's maximum boundaries on the `define_snowflake_id` macro.
- Derive `Clone` on the `crate::Error`type.