### PR TITLE
Add graceful shutdown to active client streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,7 +594,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferroid"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "base32",
  "criterion",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "ferroid-tonic-core"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "ferroid",
  "prost",
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "ferroid-tonic-server"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.9"
+version = "0.3.10"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Nick Angelou <angelou.nick@gmail.com>"]

--- a/crates/ferroid-tonic-core/Cargo.toml
+++ b/crates/ferroid-tonic-core/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 publish = true
 
 [dependencies]
-ferroid = { version = "0.3.9", path = "../ferroid" }
+ferroid = { version = "0.3.10", path = "../ferroid" }
 prost = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tonic = { workspace = true, features = ["prost", "codegen"] }

--- a/crates/ferroid-tonic-server/Cargo.toml
+++ b/crates/ferroid-tonic-server/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = { workspace = true, features = ["std"] }
 bytes = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "color", "error-context", "help", "std", "suggestions", "usage"] }
 dotenvy = { workspace = true }
-ferroid-tonic-core = { version = "0.3.9", path = "../ferroid-tonic-core" }
+ferroid-tonic-core = { version = "0.3.10", path = "../ferroid-tonic-core" }
 futures = { workspace = true }
 mimalloc = { workspace = true }
 opentelemetry = { workspace = true, optional = true }
@@ -52,30 +52,36 @@ harness = false
 default = []
 tracing = [
     "dep:tracing",
-    "opentelemetry/trace",
+    "dep:opentelemetry",
+    "opentelemetry?/trace",
     "dep:opentelemetry-otlp",
-    "opentelemetry-otlp/trace",
-    "opentelemetry_sdk/trace",
+    "opentelemetry-otlp?/trace",
+    "dep:opentelemetry_sdk",
+    "opentelemetry_sdk?/trace",
     "dep:opentelemetry-semantic-conventions",
     "dep:tracing-opentelemetry"
 ]
 metrics = [
-    "opentelemetry/metrics",
+    "dep:opentelemetry",
+    "opentelemetry?/metrics",
     "dep:opentelemetry-otlp",
-    "opentelemetry-otlp/metrics",
-    "opentelemetry_sdk/metrics",
+    "opentelemetry-otlp?/metrics",
+    "dep:opentelemetry_sdk",
+    "opentelemetry_sdk?/metrics",
     "dep:opentelemetry-semantic-conventions",
-    "tracing-opentelemetry/metrics"
+    "dep:tracing-opentelemetry",
+    "tracing-opentelemetry?/metrics"
 ]
 stdout = [
     "dep:opentelemetry-stdout",
-    "opentelemetry-stdout/trace",
-    "opentelemetry-stdout/metrics"
+    "opentelemetry-stdout?/trace",
+    "opentelemetry-stdout?/metrics"
 ]
 honeycomb = [
-    "opentelemetry-otlp/tls",
-    "opentelemetry-otlp/gzip-tonic",
-    "opentelemetry-otlp/zstd-tonic",
-    "opentelemetry-otlp/grpc-tonic",
+    "dep:opentelemetry-otlp",
+    "opentelemetry-otlp?/tls",
+    "opentelemetry-otlp?/gzip-tonic",
+    "opentelemetry-otlp?/zstd-tonic",
+    "opentelemetry-otlp?/grpc-tonic",
     "tonic/tls-native-roots"
 ]

--- a/crates/ferroid-tonic-server/src/main.rs
+++ b/crates/ferroid-tonic-server/src/main.rs
@@ -255,10 +255,12 @@ async fn shutdown_signal(
     #[cfg(feature = "tracing")]
     tracing::info!("Shutdown signal received, terminating gracefully...");
 
+    // 1. Publish the status
     health_reporter
         .set_not_serving::<IdGeneratorServer<IdService>>()
         .await;
 
+    // 2. Perform graceful shutdown
     if let Err(_e) = service.shutdown().await {
         #[cfg(feature = "tracing")]
         tracing::error!("Error during service shutdown: {:?}", _e);

--- a/crates/ferroid-tonic-server/src/server/config.rs
+++ b/crates/ferroid-tonic-server/src/server/config.rs
@@ -110,6 +110,19 @@ pub struct CliArgs {
     /// Default: `false`
     #[arg(short, long, default_value_t = false)]
     pub uds: bool,
+
+    /// Maximum time (in seconds) to wait for active client streams to complete
+    /// during shutdown.
+    ///
+    /// This grace period allows in-flight requests to finish cleanly before
+    /// forcibly shutting down workers. If the timeout is reached and streams are
+    /// still active, the server proceeds with termination and logs a warning.
+    ///
+    /// Environment variable: `SHUTDOWN_TIMEOUT`
+    ///
+    /// Default: `3`
+    #[arg(long, env = "SHUTDOWN_TIMEOUT", default_value_t = 3)]
+    pub shutdown_timeout: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -122,6 +135,7 @@ pub struct ServerConfig {
     pub chunk_bytes: usize,
     pub server_addr: String,
     pub uds: bool,
+    pub shutdown_timeout: usize,
 }
 
 impl TryFrom<CliArgs> for ServerConfig {
@@ -156,6 +170,7 @@ impl TryFrom<CliArgs> for ServerConfig {
             server_addr: args.server_addr,
             chunk_bytes,
             uds: args.uds,
+            shutdown_timeout: args.shutdown_timeout,
         })
     }
 }

--- a/crates/ferroid-tonic-server/src/server/pool/manager.rs
+++ b/crates/ferroid-tonic-server/src/server/pool/manager.rs
@@ -9,10 +9,17 @@
 //! independently. This model allows efficient parallelism without contention or
 //! locking.
 
-use crate::server::streaming::request::WorkRequest;
+use crate::server::{
+    service::handler::{get_streams, set_global_shutdown},
+    streaming::request::WorkRequest,
+};
+use core::time::Duration;
 use ferroid_tonic_core::Error;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use tokio::sync::{mpsc, oneshot};
+use tokio::{
+    sync::{mpsc, oneshot},
+    time::{sleep, timeout},
+};
 use tokio_util::sync::CancellationToken;
 
 /// A cooperative pool of asynchronous workers that process [`WorkRequest`]s.
@@ -74,10 +81,43 @@ impl WorkerPool {
     ///
     /// This method is typically invoked during service termination.
     pub async fn shutdown(&self) -> Result<(), Error> {
+        // === Phase 0: Stop accepting new requests ===
         #[cfg(feature = "tracing")]
-        tracing::info!("Initiating worker pool shutdown");
+        tracing::info!("Refusing new requests");
+        set_global_shutdown();
 
+        // === Phase 1: Wait for in-flight streams to drain (up to 3s) ===
+        #[cfg(feature = "tracing")]
+        tracing::info!("Draining in-flight streams ({} active)", get_streams());
+        let drain_result = timeout(Duration::from_secs(3), async {
+            while get_streams() > 0 {
+                sleep(Duration::from_millis(100)).await;
+            }
+        })
+        .await;
+
+        match drain_result {
+            Ok(_) => {
+                #[cfg(feature = "tracing")]
+                tracing::debug!("All in-flight streams drained successfully");
+            }
+            Err(_) => {
+                #[cfg(feature = "tracing")]
+                tracing::warn!(
+                    "Graceful drain timed out ({} streams still active)",
+                    get_streams()
+                );
+            }
+        }
+
+        // === Phase 2: Cancel any remaining work ===
+        #[cfg(feature = "tracing")]
+        tracing::debug!("Cancelling remaining work via shutdown token");
         self.shutdown_token.cancel();
+
+        // === Phase 3: Notify workers to shut down ===
+        #[cfg(feature = "tracing")]
+        tracing::debug!("Notifying all workers to shut down");
         let mut shutdown_handles = Vec::with_capacity(self.workers.len());
 
         for (i, worker) in self.workers.iter().enumerate() {
@@ -90,11 +130,14 @@ impl WorkerPool {
             }
         }
 
+        #[cfg(feature = "tracing")]
+        tracing::debug!("Waiting for up to 3s per worker for shutdown acknowledgements");
+
         let timeout_futures = shutdown_handles.into_iter().map(|(_i, rx)| async move {
-            match tokio::time::timeout(tokio::time::Duration::from_secs(3), rx).await {
+            match timeout(Duration::from_secs(3), rx).await {
                 Ok(Ok(())) => {
                     #[cfg(feature = "tracing")]
-                    tracing::debug!("Worker {_i} shutdown acknowledged");
+                    tracing::trace!("Worker {_i} shutdown acknowledged");
                 }
                 Ok(Err(_e)) => {
                     #[cfg(feature = "tracing")]

--- a/crates/ferroid-tonic-server/src/server/pool/worker.rs
+++ b/crates/ferroid-tonic-server/src/server/pool/worker.rs
@@ -58,7 +58,7 @@ pub async fn worker_loop(
             }
             WorkRequest::Shutdown { response } => {
                 #[cfg(feature = "tracing")]
-                tracing::debug!("Worker {worker_id} received shutdown signal");
+                tracing::trace!("Worker {worker_id} received shutdown signal");
 
                 if response.send(()).is_err() {
                     #[cfg(feature = "tracing")]

--- a/crates/ferroid-tonic-server/src/server/service/handler.rs
+++ b/crates/ferroid-tonic-server/src/server/service/handler.rs
@@ -128,7 +128,7 @@ impl IdService {
             tokio::spawn(worker_loop(worker_id, rx, generator, config.chunk_bytes));
         }
 
-        let worker_pool = WorkerPool::new(workers, shutdown_token);
+        let worker_pool = WorkerPool::new(workers, shutdown_token, config.shutdown_timeout);
 
         Self {
             config,

--- a/crates/ferroid-tonic-server/src/server/service/handler.rs
+++ b/crates/ferroid-tonic-server/src/server/service/handler.rs
@@ -56,12 +56,10 @@ static STREAMS_INFLIGHT: AtomicU64 = AtomicU64::new(0);
 pub fn increment_streams_inflight() {
     STREAMS_INFLIGHT.fetch_add(1, Ordering::Relaxed);
 }
-
 pub fn decrement_streams_inflight() {
     STREAMS_INFLIGHT.fetch_sub(1, Ordering::Relaxed);
 }
-
-pub fn get_streams() -> u64 {
+pub fn get_streams_inflight() -> u64 {
     STREAMS_INFLIGHT.load(Ordering::Relaxed)
 }
 

--- a/crates/ferroid-tonic-server/src/server/telemetry.rs
+++ b/crates/ferroid-tonic-server/src/server/telemetry.rs
@@ -318,42 +318,42 @@ fn init_tracer() -> anyhow::Result<sdktrace::SdkTracerProvider> {
 
 // Metric handles - only compiled when metrics feature is enabled
 #[cfg(feature = "metrics")]
-static REQUESTS: OnceLock<Counter<u64>> = OnceLock::new();
+static REQUESTS_METRIC: OnceLock<Counter<u64>> = OnceLock::new();
 #[cfg(feature = "metrics")]
-static STREAMS_INFLIGHT: OnceLock<UpDownCounter<i64>> = OnceLock::new();
+static STREAMS_INFLIGHT_METRIC: OnceLock<UpDownCounter<i64>> = OnceLock::new();
 #[cfg(feature = "metrics")]
-static STREAM_ERRORS: OnceLock<Counter<u64>> = OnceLock::new();
+static STREAM_ERRORS_METRIC: OnceLock<Counter<u64>> = OnceLock::new();
 #[cfg(feature = "metrics")]
-static STREAM_DURATION_MS: OnceLock<Histogram<f64>> = OnceLock::new();
+static STREAM_DURATION_MS_METRIC: OnceLock<Histogram<f64>> = OnceLock::new();
 #[cfg(feature = "metrics")]
-static IDS_GENERATED: OnceLock<Counter<u64>> = OnceLock::new();
+static IDS_GENERATED_METRIC: OnceLock<Counter<u64>> = OnceLock::new();
 #[cfg(feature = "metrics")]
-static IDS_PER_REQUEST: OnceLock<Histogram<f64>> = OnceLock::new();
+static IDS_PER_REQUEST_METRIC: OnceLock<Histogram<f64>> = OnceLock::new();
 
 #[cfg(feature = "metrics")]
 fn init_metric_handles(meter: Meter) {
-    let _ = REQUESTS.set(
+    let _ = REQUESTS_METRIC.set(
         meter
             .u64_counter("requests")
             .with_description("Total gRPC stream requests")
             .build(),
     );
 
-    let _ = STREAMS_INFLIGHT.set(
+    let _ = STREAMS_INFLIGHT_METRIC.set(
         meter
             .i64_up_down_counter("streams_inflight")
             .with_description("Concurrent gRPC streams")
             .build(),
     );
 
-    let _ = STREAM_ERRORS.set(
+    let _ = STREAM_ERRORS_METRIC.set(
         meter
             .u64_counter("errors")
             .with_description("Errored/cancelled streams")
             .build(),
     );
 
-    let _ = STREAM_DURATION_MS.set(
+    let _ = STREAM_DURATION_MS_METRIC.set(
         meter
             .f64_histogram("stream_duration")
             .with_unit("ms")
@@ -361,14 +361,14 @@ fn init_metric_handles(meter: Meter) {
             .build(),
     );
 
-    let _ = IDS_GENERATED.set(
+    let _ = IDS_GENERATED_METRIC.set(
         meter
             .u64_counter("ids_generated")
             .with_description("Total Snowflake IDs generated")
             .build(),
     );
 
-    let _ = IDS_PER_REQUEST.set(
+    let _ = IDS_PER_REQUEST_METRIC.set(
         meter
             .f64_histogram("ids_per_request")
             .with_description("IDs requested per stream")
@@ -378,71 +378,71 @@ fn init_metric_handles(meter: Meter) {
 
 // Convenience functions that compile to no-ops when metrics are disabled
 #[cfg(feature = "metrics")]
-pub fn increment_requests() {
-    if let Some(counter) = REQUESTS.get() {
+pub fn increment_requests_metric() {
+    if let Some(counter) = REQUESTS_METRIC.get() {
         counter.add(1, &[]);
     }
 }
 
 #[cfg(not(feature = "metrics"))]
-pub fn increment_requests() {}
+pub fn increment_requests_metric() {}
 
 #[cfg(feature = "metrics")]
-pub fn increment_streams_inflight() {
-    if let Some(counter) = STREAMS_INFLIGHT.get() {
+pub fn increment_streams_inflight_metric() {
+    if let Some(counter) = STREAMS_INFLIGHT_METRIC.get() {
         counter.add(1, &[]);
     }
 }
 
 #[cfg(not(feature = "metrics"))]
-pub fn increment_streams_inflight() {}
+pub fn increment_streams_inflight_metric() {}
 
 #[cfg(feature = "metrics")]
-pub fn decrement_streams_inflight() {
-    if let Some(counter) = STREAMS_INFLIGHT.get() {
+pub fn decrement_streams_inflight_metric() {
+    if let Some(counter) = STREAMS_INFLIGHT_METRIC.get() {
         counter.add(-1, &[]);
     }
 }
 
 #[cfg(not(feature = "metrics"))]
-pub fn decrement_streams_inflight() {}
+pub fn decrement_streams_inflight_metric() {}
 
 #[cfg(feature = "metrics")]
-pub fn increment_stream_errors() {
-    if let Some(counter) = STREAM_ERRORS.get() {
+pub fn increment_stream_errors_metric() {
+    if let Some(counter) = STREAM_ERRORS_METRIC.get() {
         counter.add(1, &[]);
     }
 }
 
 #[cfg(not(feature = "metrics"))]
-pub fn increment_stream_errors() {}
+pub fn increment_stream_errors_metric() {}
 
 #[cfg(feature = "metrics")]
-pub fn record_stream_duration(duration_ms: f64) {
-    if let Some(histogram) = STREAM_DURATION_MS.get() {
+pub fn record_stream_duration_metric(duration_ms: f64) {
+    if let Some(histogram) = STREAM_DURATION_MS_METRIC.get() {
         histogram.record(duration_ms, &[]);
     }
 }
 
 #[cfg(not(feature = "metrics"))]
-pub fn record_stream_duration(_duration_ms: f64) {}
+pub fn record_stream_duration_metric(_duration_ms: f64) {}
 
 #[cfg(feature = "metrics")]
-pub fn increment_ids_generated(count: u64) {
-    if let Some(counter) = IDS_GENERATED.get() {
+pub fn increment_ids_generated_metric(count: u64) {
+    if let Some(counter) = IDS_GENERATED_METRIC.get() {
         counter.add(count, &[]);
     }
 }
 
 #[cfg(not(feature = "metrics"))]
-pub fn increment_ids_generated(_count: u64) {}
+pub fn increment_ids_generated_metric(_count: u64) {}
 
 #[cfg(feature = "metrics")]
-pub fn record_ids_per_request(count: f64) {
-    if let Some(histogram) = IDS_PER_REQUEST.get() {
+pub fn record_ids_per_request_metric(count: f64) {
+    if let Some(histogram) = IDS_PER_REQUEST_METRIC.get() {
         histogram.record(count, &[]);
     }
 }
 
 #[cfg(not(feature = "metrics"))]
-pub fn record_ids_per_request(_count: f64) {}
+pub fn record_ids_per_request_metric(_count: f64) {}


### PR DESCRIPTION
This PR adds full support for cooperative, graceful shutdown of the `ferroid-tonic-serve` process. It ensures that in-flight client streams are allowed to complete before worker tasks are terminated.

On shutdown:
- New requests are refused immediately
- Active streams are given a chance to finish (configurable by `--shutdown-timeout`)
- Workers are terminated cleanly
- Timeouts or errors are logged but do not block shutdown completion