### PR TITLE
Remove feature-gated base32 field from macro-generated Debug impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,7 +594,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferroid"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-lock",
  "base32",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "ferroid-tonic-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "ferroid",
  "prost",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "ferroid-tonic-server"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Nick Angelou <angelou.nick@gmail.com>"]

--- a/crates/ferroid-tonic-core/Cargo.toml
+++ b/crates/ferroid-tonic-core/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 publish = true
 
 [dependencies]
-ferroid = { version = "0.4.0", path = "../ferroid", features = ["snowflake", "ulid"] }
+ferroid = { version = "0.4.1", path = "../ferroid", features = ["snowflake", "ulid"] }
 prost = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tonic = { workspace = true, features = ["prost", "codegen"] }

--- a/crates/ferroid-tonic-server/Cargo.toml
+++ b/crates/ferroid-tonic-server/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = { workspace = true, features = ["std"] }
 bytes = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "color", "error-context", "help", "std", "suggestions", "usage"] }
 dotenvy = { workspace = true }
-ferroid-tonic-core = { version = "0.4.0", path = "../ferroid-tonic-core" }
+ferroid-tonic-core = { version = "0.4.1", path = "../ferroid-tonic-core" }
 futures = { workspace = true }
 mimalloc = { workspace = true }
 opentelemetry = { workspace = true, optional = true }

--- a/crates/ferroid/src/id/snowflake.rs
+++ b/crates/ferroid/src/id/snowflake.rs
@@ -274,24 +274,16 @@ macro_rules! define_snowflake_id {
 
         impl core::fmt::Debug for $name {
             fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                use $crate::Snowflake;
+
                 let full = core::any::type_name::<Self>();
                 let name = full.rsplit("::").next().unwrap_or(full);
                 let mut dbg = f.debug_struct(name);
                 dbg.field("id", &format_args!("{:} (0x{:x})", self.to_raw(), self.to_raw()));
-
-                use $crate::Snowflake;
                 dbg.field("padded", &self.to_padded_string());
-
-                #[cfg(feature = "base32")]
-                {
-                    use $crate::Base32Ext;
-                    dbg.field("base32", &self.encode());
-                }
-
                 dbg.field("timestamp", &format_args!("{:} (0x{:x})", self.timestamp(), self.timestamp()));
                 dbg.field("machine_id", &format_args!("{:} (0x{:x})", self.machine_id(), self.machine_id()));
                 dbg.field("sequence", &format_args!("{:} (0x{:x})", self.sequence(), self.sequence()));
-
                 dbg.finish()
             }
         }

--- a/crates/ferroid/src/id/ulid.rs
+++ b/crates/ferroid/src/id/ulid.rs
@@ -198,23 +198,15 @@ macro_rules! define_ulid {
 
         impl core::fmt::Debug for $name {
             fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                use $crate::Ulid;
+                
                 let full = core::any::type_name::<Self>();
                 let name = full.rsplit("::").next().unwrap_or(full);
                 let mut dbg = f.debug_struct(name);
                 dbg.field("id", &format_args!("{:} (0x{:x})", self.to_raw(), self.to_raw()));
-
-                use $crate::Ulid;
                 dbg.field("padded", &self.to_padded_string());
-
-                #[cfg(feature = "base32")]
-                {
-                    use $crate::Base32Ext;
-                    dbg.field("base32", &self.encode());
-                }
-
                 dbg.field("timestamp", &format_args!("{:} (0x{:x})", self.timestamp(), self.timestamp()));
                 dbg.field("random", &format_args!("{:} (0x{:x})", self.random(), self.random()));
-
                 dbg.finish()
             }
         }


### PR DESCRIPTION
Closes #14 

This PR updates the macro-generated `Debug` implementations for both `define_snowflake_id!` and `define_ulid!` to remove the conditional `base32` field that was previously included only when the `base32` feature was enabled.

Rather than working around the `unexpected_cfg` warnings introduced by feature gating inside macros, this change opts for a cleaner separation of concerns. Including encoded output in `Debug` is both expensive and arguably outside the scope of native debug formatting.

Users who want to work with base32-encoded representations can still opt in via the base32 feature and explicitly call `.encode()` or `.decode()`. This preserves functionality while keeping the debug experience predictable, fast, and free of feature leakage.