### PR TITLE
Impl faster base32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,7 +594,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferroid"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-lock",
  "base32",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "ferroid-tonic-core"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "ferroid",
  "prost",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "ferroid-tonic-server"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Nick Angelou <angelou.nick@gmail.com>"]

--- a/crates/ferroid-tonic-core/Cargo.toml
+++ b/crates/ferroid-tonic-core/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 publish = true
 
 [dependencies]
-ferroid = { version = "0.4.3", path = "../ferroid", features = ["snowflake", "ulid"] }
+ferroid = { version = "0.4.4", path = "../ferroid", features = ["snowflake", "ulid"] }
 prost = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tonic = { workspace = true, features = ["prost", "codegen"] }

--- a/crates/ferroid-tonic-server/Cargo.toml
+++ b/crates/ferroid-tonic-server/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = { workspace = true, features = ["std"] }
 bytes = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "color", "error-context", "help", "std", "suggestions", "usage"] }
 dotenvy = { workspace = true }
-ferroid-tonic-core = { version = "0.4.3", path = "../ferroid-tonic-core" }
+ferroid-tonic-core = { version = "0.4.4", path = "../ferroid-tonic-core" }
 futures = { workspace = true }
 mimalloc = { workspace = true }
 opentelemetry = { workspace = true, optional = true }

--- a/crates/ferroid/benches/bench.rs
+++ b/crates/ferroid/benches/bench.rs
@@ -1,4 +1,5 @@
 use core::hint::black_box;
+use core::time::Duration;
 use criterion::async_executor::SmolExecutor;
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use ferroid::{
@@ -8,7 +9,6 @@ use ferroid::{
     ThreadRandom, TimeSource, ToU64, TokioSleep, ULID, Ulid, UlidGenerator, UlidGeneratorAsyncExt,
 };
 use futures::future::try_join_all;
-use std::time::Duration;
 use std::{thread::scope, time::Instant};
 use tokio::runtime::Builder;
 
@@ -148,11 +148,9 @@ fn bench_generator_threaded<ID, G, T>(
                                                     break;
                                                 }
                                                 IdGenStatus::Pending { yield_for } => {
-                                                    std::thread::sleep(
-                                                        std::time::Duration::from_millis(
-                                                            yield_for.to_u64()?,
-                                                        ),
-                                                    );
+                                                    std::thread::sleep(Duration::from_millis(
+                                                        yield_for.to_u64()?,
+                                                    ));
                                                 }
                                             }
                                         }
@@ -360,11 +358,9 @@ fn bench_generator_ulid_threaded<ID, G, T, R>(
                                                     break;
                                                 }
                                                 IdGenStatus::Pending { yield_for } => {
-                                                    std::thread::sleep(
-                                                        std::time::Duration::from_millis(
-                                                            yield_for.to_u64()?,
-                                                        ),
-                                                    );
+                                                    std::thread::sleep(Duration::from_millis(
+                                                        yield_for.to_u64()?,
+                                                    ));
                                                 }
                                             }
                                         }
@@ -731,8 +727,7 @@ fn bench_generator_threaded_basic(c: &mut Criterion) {
         MonotonicClock::default,
     )
 }
-/// Multi-threaded benchmark for `LockSnowflakeGenerator` with
-/// `MonotonicClock`.
+/// Multi-threaded benchmark for `LockSnowflakeGenerator` with `MonotonicClock`.
 fn bench_generator_threaded_lock(c: &mut Criterion) {
     bench_generator_threaded::<SnowflakeTwitterId, _, _>(
         c,
@@ -885,6 +880,7 @@ fn bench_base32(c: &mut Criterion) {
 criterion_group!(
     benches,
     // --- Snowflake ---
+    //
     // Mock clock
     benchmark_mock_sequential_basic,
     benchmark_mock_sequential_lock,
@@ -903,6 +899,7 @@ criterion_group!(
     benchmark_mono_smol_lock,
     benchmark_mono_smol_atomic,
     // --- Ulid ---
+    //
     // Mock clock
     benchmark_mock_sequential_ulid_basic,
     benchmark_mock_sequential_ulid_lock,

--- a/crates/ferroid/benches/bench.rs
+++ b/crates/ferroid/benches/bench.rs
@@ -539,47 +539,41 @@ fn bench_snowflake_base32<ID, G, T>(
         b.iter_custom(|iters| {
             let mut buf = <ID::Ty as BeBytes>::Base32Array::default();
             let start = Instant::now();
+
             for _ in 0..iters {
                 for id in &ids {
-                    id.encode_to_buf(&mut buf);
+                    black_box(id.encode_to_buf(black_box(&mut buf)));
                 }
             }
+
             start.elapsed()
         });
     });
-
-    group.finish();
-
-    let mut group = c.benchmark_group(group_name);
-    group.throughput(Throughput::Elements(TOTAL_IDS as u64));
 
     group.bench_function(format!("encode_to_string/elems/{}", TOTAL_IDS), |b| {
         b.iter_custom(|iters| {
             let start = Instant::now();
+
             for _ in 0..iters {
                 for id in &ids {
-                    let enc = id.encode();
-                    black_box(enc);
+                    black_box(id.encode());
                 }
             }
+
             start.elapsed()
         });
     });
 
-    group.finish();
-
-    let mut group = c.benchmark_group(group_name);
-    group.throughput(Throughput::Elements(TOTAL_IDS as u64));
-
     group.bench_function(format!("decode/elems/{}", TOTAL_IDS), |b| {
         b.iter_custom(|iters| {
             let start = Instant::now();
+
             for _ in 0..iters {
                 for enc in &encoded {
-                    let id = ID::decode(enc).unwrap();
-                    black_box(id);
+                    black_box(ID::decode(black_box(enc)).unwrap());
                 }
             }
+
             start.elapsed()
         });
     });
@@ -632,47 +626,41 @@ fn bench_ulid_base32<ID, G, T, R>(
         b.iter_custom(|iters| {
             let mut buf = <ID::Ty as BeBytes>::Base32Array::default();
             let start = Instant::now();
+
             for _ in 0..iters {
                 for id in &ids {
-                    id.encode_to_buf(&mut buf);
+                    black_box(id.encode_to_buf(black_box(&mut buf)));
                 }
             }
+
             start.elapsed()
         });
     });
-
-    group.finish();
-
-    let mut group = c.benchmark_group(group_name);
-    group.throughput(Throughput::Elements(TOTAL_IDS as u64));
 
     group.bench_function(format!("encode_to_string/elems/{}", TOTAL_IDS), |b| {
         b.iter_custom(|iters| {
             let start = Instant::now();
+
             for _ in 0..iters {
                 for id in &ids {
-                    let enc = id.encode();
-                    black_box(enc);
+                    black_box(id.encode());
                 }
             }
+
             start.elapsed()
         });
     });
 
-    group.finish();
-
-    let mut group = c.benchmark_group(group_name);
-    group.throughput(Throughput::Elements(TOTAL_IDS as u64));
-
     group.bench_function(format!("decode/elems/{}", TOTAL_IDS), |b| {
         b.iter_custom(|iters| {
             let start = Instant::now();
+
             for _ in 0..iters {
                 for enc in &encoded {
-                    let id = ID::decode(enc).unwrap();
-                    black_box(id);
+                    black_box(ID::decode(black_box(enc)).unwrap());
                 }
             }
+
             start.elapsed()
         });
     });

--- a/crates/ferroid/src/base32.rs
+++ b/crates/ferroid/src/base32.rs
@@ -1,4 +1,5 @@
 use crate::{Error, Id, Result};
+use core::array::TryFromSliceError;
 use core::convert::TryInto;
 use core::fmt;
 
@@ -28,9 +29,7 @@ impl BeBytes for u32 {
     }
 
     fn from_be_bytes(bytes: &[u8]) -> Result<Self> {
-        let arr: [u8; Self::SIZE] = bytes
-            .try_into()
-            .map_err(|e| Base32Error::TryFromSliceError(e))?;
+        let arr: [u8; Self::SIZE] = bytes.try_into().map_err(Base32Error::from)?;
         Ok(Self::from_be_bytes(arr))
     }
 }
@@ -46,9 +45,7 @@ impl BeBytes for u64 {
     }
 
     fn from_be_bytes(bytes: &[u8]) -> Result<Self> {
-        let arr: [u8; Self::SIZE] = bytes
-            .try_into()
-            .map_err(|e| Base32Error::TryFromSliceError(e))?;
+        let arr: [u8; Self::SIZE] = bytes.try_into().map_err(Base32Error::from)?;
         Ok(Self::from_be_bytes(arr))
     }
 }
@@ -64,9 +61,7 @@ impl BeBytes for u128 {
     }
 
     fn from_be_bytes(bytes: &[u8]) -> Result<Self> {
-        let arr: [u8; Self::SIZE] = bytes
-            .try_into()
-            .map_err(|e| Base32Error::TryFromSliceError(e))?;
+        let arr: [u8; Self::SIZE] = bytes.try_into().map_err(Base32Error::from)?;
         Ok(Self::from_be_bytes(arr))
     }
 }
@@ -102,7 +97,7 @@ where
 pub enum Base32Error {
     DecodeInvalidLen,
     DecodeInvalidAscii,
-    TryFromSliceError(std::array::TryFromSliceError),
+    TryFromSliceError(core::array::TryFromSliceError),
 }
 impl fmt::Display for Base32Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -117,6 +112,12 @@ impl core::error::Error for Base32Error {}
 impl From<Base32Error> for Error {
     fn from(err: Base32Error) -> Self {
         Error::Base32Error(err)
+    }
+}
+
+impl From<TryFromSliceError> for Base32Error {
+    fn from(err: TryFromSliceError) -> Self {
+        Base32Error::TryFromSliceError(err)
     }
 }
 

--- a/crates/ferroid/src/base32.rs
+++ b/crates/ferroid/src/base32.rs
@@ -89,7 +89,6 @@ impl<ID> Base32Ext for ID
 where
     ID: Id,
     ID::Ty: BeBytes,
-    <ID::Ty as BeBytes>::ByteArray: Default + AsMut<[u8]>,
 {
 }
 

--- a/crates/ferroid/src/base32.rs
+++ b/crates/ferroid/src/base32.rs
@@ -80,7 +80,7 @@ where
     }
 
     fn decode(s: &str) -> Result<Self> {
-        let raw = decode_base32::<Self::Ty>(s)?;
+        let raw = decode_base32(s)?;
         Ok(Self::from_raw(raw))
     }
 }

--- a/crates/ferroid/src/base32.rs
+++ b/crates/ferroid/src/base32.rs
@@ -135,20 +135,20 @@ where
     }
     /// Decodes a Base32-encoded string back into an ID.
     ///
-    /// **Note:** This method performs a structural decode of the Base32 string
-    /// into the raw underlying integer. It does **not** validate whether the
-    /// decoded value adheres to the ID's semantic constraints (e.g., reserved
-    /// bits, out-of-range fields).
+    /// ⚠️ **Note:** This method performs a structural decode of the Base32
+    /// string into the raw underlying integer. It does **not** validate whether
+    /// the decoded value satisfies semantic invariants of the ID format (e.g.,
+    /// reserved bits).
     ///
-    /// If validation is required, use `.is_valid()` to check, or
-    /// `.into_valid()` to normalize the value.
+    /// If your ID type includes reserved bits, you should explicitly validate
+    /// the result using `.is_valid()` or normalize it using `.into_valid()`.
     ///
     /// # Errors
     ///
     /// Returns an error if the input string:
     /// - is not the expected fixed length
-    /// - contains characters not in the Crockford Base32 alphabet (invalid
-    ///   ASCII)
+    /// - contains invalid ASCII characters (i.e., not in the Crockford Base32
+    ///   alphabet)
     ///
     /// # Example
     ///
@@ -157,24 +157,22 @@ where
     /// {
     ///     use ferroid::{Base32Ext, Snowflake, SnowflakeTwitterId};
     ///
-    ///     // A valid encoded ID
+    ///     // A syntactically and semantically valid ID
     ///     let encoded = "46JA7902CV4V4";
     ///     let decoded = SnowflakeTwitterId::decode(encoded).unwrap();
-    ///
     ///     assert!(decoded.is_valid());
     ///     assert_eq!(decoded.to_raw(), 2_424_242_424_242_424_242);
     ///
-    ///     // A syntactically valid but semantically invalid `SnowflakeTwitterId` - sets reserved bits
+    ///     // A syntactically valid but semantically invalid ID (sets the reserved bit in `SnowflakeTwitterId`)
     ///     let encoded = "ZZZZZZZZZZZZZ";
     ///     let decoded = SnowflakeTwitterId::decode(encoded).unwrap();
-    ///
     ///     assert!(!decoded.is_valid());
     ///     assert_eq!(decoded.to_raw(), u64::MAX);
     ///
     ///     // Normalize to a valid representation
     ///     let valid = decoded.into_valid();
     ///     assert!(valid.is_valid());
-    ///     assert_eq!(valid.to_raw(), 9_223_372_036_854_775_807); // max valid `SnowflakeTwitterId`
+    ///     assert_eq!(valid.to_raw(), 9_223_372_036_854_775_807); // max valid SnowflakeTwitterId
     /// }
     /// ```
     fn decode(s: &str) -> Result<Self> {

--- a/crates/ferroid/src/base32.rs
+++ b/crates/ferroid/src/base32.rs
@@ -141,7 +141,7 @@ const LOOKUP: [u8; 256] = {
 
 pub fn encode_base32<T: BeBytes>(value: T, buf: &mut T::Base32Array) {
     let mut bits = 0usize;
-    let mut acc = 0u16;
+    let mut acc = 0_u16;
 
     let raw = value.to_be_bytes();
     let bytes = raw.as_ref();
@@ -179,8 +179,8 @@ fn decode_base32<T: BeBytes>(s: &str) -> Result<T> {
     let out_bytes = out.as_mut();
 
     // Reverse the encoding process - accumulate bits and write to bytes
-    let mut bits = 0usize;
-    let mut acc = 0u16;
+    let mut bits = 0_usize;
+    let mut acc = 0_u16;
     let mut byte_idx = 0;
 
     for &b in bytes {
@@ -198,13 +198,6 @@ fn decode_base32<T: BeBytes>(s: &str) -> Result<T> {
             out_bytes[byte_idx] = (acc >> bits) as u8;
             byte_idx += 1;
         }
-    }
-
-    // Handle any remaining bits in the last partial byte
-    if bits > 0 && byte_idx < out_bytes.len() {
-        // Shift remaining bits to the left to fill the byte
-        let remaining_bits = 8 - bits;
-        out_bytes[byte_idx] = (acc << remaining_bits) as u8;
     }
 
     T::from_be_bytes(out_bytes)

--- a/crates/ferroid/src/base32.rs
+++ b/crates/ferroid/src/base32.rs
@@ -74,10 +74,14 @@ where
 {
     fn encode(&self) -> String {
         let mut buf = <Self::Ty as BeBytes>::Base32Array::default();
-        encode_base32(self.to_raw(), &mut buf);
+        self.encode_to_buf(&mut buf);
 
         // SAFTEY: Base32 is always valid ASCII
         unsafe { String::from_utf8_unchecked(buf.as_ref().to_vec()) }
+    }
+
+    fn encode_to_buf(&self, buf: &mut <<Self as Id>::Ty as BeBytes>::Base32Array) {
+        encode_base32(self.to_raw(), buf);
     }
 
     fn decode(s: &str) -> Result<Self> {
@@ -237,8 +241,10 @@ mod snowflake_tests {
         T::Ty: BeBytes + fmt::Binary + fmt::LowerHex + fmt::Display + fmt::Debug,
     {
         let raw = id.to_raw();
-        let encoded = id.encode();
-        let decoded = T::decode(&encoded).expect("decode should succeed");
+        let mut buf = <T::Ty as BeBytes>::Base32Array::default();
+        id.encode_to_buf(&mut buf);
+        let encoded = core::str::from_utf8(buf.as_ref()).unwrap();
+        let decoded = T::decode(encoded).expect("decode should succeed");
 
         let type_name = type_name::<T>();
 
@@ -385,8 +391,11 @@ mod ulid_tests {
         T::Ty: BeBytes + fmt::Binary + fmt::LowerHex + fmt::Display + fmt::Debug,
     {
         let raw = id.to_raw();
-        let encoded = id.encode();
-        let decoded = T::decode(&encoded).expect("decode should succeed");
+
+        let mut buf = <T::Ty as BeBytes>::Base32Array::default();
+        id.encode_to_buf(&mut buf);
+        let encoded = core::str::from_utf8(buf.as_ref()).unwrap();
+        let decoded = T::decode(encoded).expect("decode should succeed");
 
         let type_name = type_name::<T>();
 

--- a/crates/ferroid/src/error.rs
+++ b/crates/ferroid/src/error.rs
@@ -9,9 +9,7 @@ pub enum Error {
     LockPoisoned,
     FailedToU64,
     #[cfg(feature = "base32")]
-    DecodeNonAsciiValue,
-    #[cfg(feature = "base32")]
-    DecodeInvalidLen,
+    Base32Error(crate::Base32Error),
 }
 
 impl fmt::Display for Error {

--- a/crates/ferroid/src/id/id.rs
+++ b/crates/ferroid/src/id/id.rs
@@ -7,6 +7,12 @@ use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 pub trait Id:
     Copy + Clone + fmt::Display + PartialOrd + Ord + PartialEq + Eq + Hash + fmt::Debug
 {
+    /// Zero value (used for resetting the sequence)
+    const ZERO: Self::Ty;
+
+    /// One value (used for incrementing the sequence)
+    const ONE: Self::Ty;
+
     /// Scalar type for all bit fields (typically `u64` or `u128`)
     type Ty: Copy
         + Clone

--- a/crates/ferroid/src/id/id.rs
+++ b/crates/ferroid/src/id/id.rs
@@ -27,8 +27,9 @@ pub trait Id:
         + Eq
         + PartialEq
         + Hash
+        // For clock millis and testing
         + ToU64
-        // For testing
+        // For base32 decode and testing
         + From<u8>
         // Arithmetic
         + Add<Output = Self::Ty>

--- a/crates/ferroid/src/id/id.rs
+++ b/crates/ferroid/src/id/id.rs
@@ -16,6 +16,7 @@ pub trait Id:
     /// Scalar type for all bit fields (typically `u64` or `u128`)
     type Ty: Copy
         + Clone
+        + Default
         + Add<Output = Self::Ty>
         + AddAssign
         + Sub<Output = Self::Ty>
@@ -32,6 +33,17 @@ pub trait Id:
         + ToU64
         + fmt::Debug
         + fmt::Display
+        + From<u8>
+        + core::ops::Shl<usize, Output = Self::Ty>
+        + core::ops::Shr<usize, Output = Self::Ty>
+        + core::ops::ShlAssign
+        + core::ops::ShrAssign
+        + core::ops::BitOr<Output = Self::Ty>
+        + core::ops::BitAnd<Output = Self::Ty>
+        + core::ops::BitXor<Output = Self::Ty>
+        + core::ops::BitAndAssign
+        + core::ops::BitOrAssign
+        + core::ops::BitXorAssign
         + Into<Self::Ty>
         + From<Self::Ty>;
 

--- a/crates/ferroid/src/id/id.rs
+++ b/crates/ferroid/src/id/id.rs
@@ -1,7 +1,10 @@
 use crate::ToU64;
-use std::fmt;
-use std::hash::Hash;
-use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
+use core::fmt;
+use core::hash::Hash;
+use core::ops::{
+    Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div, DivAssign,
+    Mul, MulAssign, Not, Shl, ShlAssign, Shr, ShrAssign, Sub, SubAssign,
+};
 
 // Common trait that captures the shared behavior
 pub trait Id:
@@ -17,35 +20,46 @@ pub trait Id:
     type Ty: Copy
         + Clone
         + Default
-        + Add<Output = Self::Ty>
-        + AddAssign
-        + Sub<Output = Self::Ty>
-        + SubAssign
-        + Mul<Output = Self::Ty>
-        + MulAssign
-        + Div<Output = Self::Ty>
-        + DivAssign
+        + fmt::Debug
+        + fmt::Display
         + Ord
         + PartialOrd
         + Eq
         + PartialEq
         + Hash
         + ToU64
-        + fmt::Debug
-        + fmt::Display
+        // For testing
         + From<u8>
-        + core::ops::Shl<usize, Output = Self::Ty>
-        + core::ops::Shr<usize, Output = Self::Ty>
-        + core::ops::ShlAssign
-        + core::ops::ShrAssign
-        + core::ops::BitOr<Output = Self::Ty>
-        + core::ops::BitAnd<Output = Self::Ty>
-        + core::ops::BitXor<Output = Self::Ty>
-        + core::ops::BitAndAssign
-        + core::ops::BitOrAssign
-        + core::ops::BitXorAssign
-        + Into<Self::Ty>
-        + From<Self::Ty>;
+        // Arithmetic
+        + Add<Output = Self::Ty>
+        + AddAssign<Self::Ty>
+        + Sub<Output = Self::Ty>
+        + SubAssign<Self::Ty>
+        + Mul<Output = Self::Ty>
+        + MulAssign<Self::Ty>
+        + Div<Output = Self::Ty>
+        + DivAssign<Self::Ty>
+        // Bitwise
+        + BitOr<Output = Self::Ty>
+        + BitOrAssign<Self::Ty>
+        + BitAnd<Output = Self::Ty>
+        + BitAndAssign<Self::Ty>
+        + BitXor<Output = Self::Ty>
+        + BitXorAssign<Self::Ty>
+        + Not<Output = Self::Ty>
+        // Shifting
+        + Shl<u8, Output = Self::Ty>
+        + Shr<u8, Output = Self::Ty>
+        + Shl<u32, Output = Self::Ty>
+        + Shr<u32, Output = Self::Ty>
+        + Shl<u64, Output = Self::Ty>
+        + Shr<u64, Output = Self::Ty>
+        + Shl<u128, Output = Self::Ty>
+        + Shr<u128, Output = Self::Ty>
+        + Shl<usize, Output = Self::Ty>
+        + Shr<usize, Output = Self::Ty>
+        + ShlAssign<Self::Ty>
+        + ShrAssign<Self::Ty>;
 
     /// Converts this type into its raw type representation
     fn to_raw(&self) -> Self::Ty;

--- a/crates/ferroid/src/id/snowflake.rs
+++ b/crates/ferroid/src/id/snowflake.rs
@@ -21,12 +21,6 @@ use core::{fmt, hash::Hash};
 pub trait Snowflake:
     Id + Copy + Clone + fmt::Display + PartialOrd + Ord + PartialEq + Eq + Hash
 {
-    /// Zero value (used for resetting the sequence)
-    const ZERO: Self::Ty;
-
-    /// One value (used for incrementing the sequence)
-    const ONE: Self::Ty;
-
     /// Returns the timestamp portion of the ID.
     fn timestamp(&self) -> Self::Ty;
 
@@ -207,6 +201,8 @@ macro_rules! define_snowflake_id {
 
         impl $crate::Id for $name {
             type Ty = $int;
+            const ZERO: $int = 0;
+            const ONE: $int = 1;
 
             /// Converts this type into its raw type representation
             fn to_raw(&self) -> Self::Ty {
@@ -220,9 +216,6 @@ macro_rules! define_snowflake_id {
         }
 
         impl $crate::Snowflake for $name {
-            const ZERO: $int = 0;
-            const ONE: $int = 1;
-
             fn timestamp(&self) -> Self::Ty {
                 self.timestamp()
             }

--- a/crates/ferroid/src/id/snowflake.rs
+++ b/crates/ferroid/src/id/snowflake.rs
@@ -62,6 +62,14 @@ pub trait Snowflake:
         Self::from_components(ts, self.machine_id(), Self::ZERO)
     }
 
+    /// Returns `true` if the ID's internal structure is valid, such as reserved
+    /// bits being unset or fields within expected ranges.
+    fn is_valid(&self) -> bool;
+
+    /// Returns a normalized version of the ID with any invalid or reserved bits
+    /// cleared. This guarantees a valid, canonical representation.
+    fn into_valid(self) -> Self;
+
     fn to_padded_string(&self) -> String;
 }
 
@@ -245,6 +253,14 @@ macro_rules! define_snowflake_id {
                 debug_assert!(machine_id <= Self::MACHINE_ID_MASK, "machine_id overflow");
                 debug_assert!(sequence <= Self::SEQUENCE_MASK, "sequence overflow");
                 Self::from(timestamp, machine_id, sequence)
+            }
+
+            fn is_valid(&self) -> bool {
+                *self == Self::from_components(self.timestamp(), self.machine_id(), self.sequence())
+            }
+
+            fn into_valid(self) -> Self {
+                Self::from_components(self.timestamp(), self.machine_id(), self.sequence())
             }
 
             fn to_padded_string(&self) -> String {

--- a/crates/ferroid/src/id/ulid.rs
+++ b/crates/ferroid/src/id/ulid.rs
@@ -12,12 +12,6 @@ use core::{fmt, hash::Hash};
 pub trait Ulid:
     Id + Copy + Clone + fmt::Display + PartialOrd + Ord + PartialEq + Eq + Hash + fmt::Debug
 {
-    /// Zero value (used for resetting the sequence)
-    const ZERO: Self::Ty;
-
-    /// One value (used for incrementing the sequence)
-    const ONE: Self::Ty;
-
     /// Returns the timestamp portion of the ID.
     fn timestamp(&self) -> Self::Ty;
 
@@ -59,13 +53,13 @@ pub trait Ulid:
 /// # Field Ordering Semantics
 ///
 /// The `define_ulid!` macro defines a bit layout for a custom Ulid using four
-/// required components: `reserved`, `timestamp`, `random`, and `sequence`.
+/// required components: `reserved`, `timestamp`, and `random`.
 ///
 /// These components are always laid out from **most significant bit (MSB)** to
 /// **least significant bit (LSB)** - in that exact order.
 ///
 /// - The first field (`reserved`) occupies the highest bits.
-/// - The last field (`sequence`) occupies the lowest bits.
+/// - The last field (`random`) occupies the lowest bits.
 /// - The total number of bits **must exactly equal** the size of the backing
 ///   integer type (`u64`, `u128`, etc.). If it doesn't, the macro will trigger
 ///   a compile-time assertion failure.
@@ -75,7 +69,6 @@ pub trait Ulid:
 ///     <TypeName>, <IntegerType>,
 ///     reserved: <bits>,
 ///     timestamp: <bits>,
-///     sequence: <bits>,
 ///     random: <bits>
 /// );
 ///```
@@ -177,6 +170,8 @@ macro_rules! define_ulid {
 
         impl $crate::Id for $name {
             type Ty = $int;
+            const ZERO: $int = 0;
+            const ONE: $int = 1;
 
             /// Converts this type into its raw type representation
             fn to_raw(&self) -> Self::Ty {
@@ -190,9 +185,6 @@ macro_rules! define_ulid {
         }
 
         impl $crate::Ulid for $name {
-            const ZERO: $int = 0;
-            const ONE: $int = 1;
-
             fn timestamp(&self) -> Self::Ty {
                 self.timestamp()
             }


### PR DESCRIPTION
Removes dependence on `base32` crate for a more optimized solution.