### PR TITLE
Add from timestamp and datetime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,7 +594,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferroid"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "async-lock",
  "base32",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "ferroid-tonic-core"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "ferroid",
  "prost",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "ferroid-tonic-server"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Nick Angelou <angelou.nick@gmail.com>"]

--- a/crates/ferroid-tonic-core/Cargo.toml
+++ b/crates/ferroid-tonic-core/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 publish = true
 
 [dependencies]
-ferroid = { version = "0.5.2", path = "../ferroid", features = ["snowflake", "ulid"] }
+ferroid = { version = "0.5.3", path = "../ferroid", features = ["snowflake", "ulid"] }
 prost = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tonic = { workspace = true, features = ["prost", "codegen"] }

--- a/crates/ferroid-tonic-server/Cargo.toml
+++ b/crates/ferroid-tonic-server/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = { workspace = true, features = ["std"] }
 bytes = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "color", "error-context", "help", "std", "suggestions", "usage"] }
 dotenvy = { workspace = true }
-ferroid-tonic-core = { version = "0.5.2", path = "../ferroid-tonic-core" }
+ferroid-tonic-core = { version = "0.5.3", path = "../ferroid-tonic-core" }
 futures = { workspace = true }
 mimalloc = { workspace = true }
 opentelemetry = { workspace = true, optional = true }


### PR DESCRIPTION
This PR introduces four convenience constructors to the ULID implementation:

- `from_timestamp(timestamp)`
- `from_timestamp_and_rand(timestamp, rng)`
- `from_datetime(datetime)`
- `from_datetime_and_rand(datetime, rng)`

These methods make it easier to construct ULIDs from either a millisecond timestamp or a `SystemTime`, with optional support for custom random sources via the `RandSource `trait. Internally, `ThreadRandom` is used as the default RNG when none is provided.

All methods are infallible and treat pre-epoch times as zero. Additionally, the internal `MonotonicClock` is now infallible - any `SystemTime` or offset earlier than the UNIX epoch is treated as zero. This behavior aligns with the new ULID constructors for consistent and predictable behavior.