### PR TITLE
Refactor Base32 formatting API for ULID and Snowflake with zero-allocation formatters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,7 +594,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferroid"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "async-lock",
  "base32",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "ferroid-tonic-core"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "ferroid",
  "prost",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "ferroid-tonic-server"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Nick Angelou <angelou.nick@gmail.com>"]

--- a/crates/ferroid-tonic-core/Cargo.toml
+++ b/crates/ferroid-tonic-core/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 publish = true
 
 [dependencies]
-ferroid = { version = "0.5.3", path = "../ferroid", features = ["snowflake", "ulid"] }
+ferroid = { version = "0.5.4", path = "../ferroid", features = ["snowflake", "ulid"] }
 prost = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tonic = { workspace = true, features = ["prost", "codegen"] }

--- a/crates/ferroid-tonic-server/Cargo.toml
+++ b/crates/ferroid-tonic-server/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = { workspace = true, features = ["std"] }
 bytes = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "color", "error-context", "help", "std", "suggestions", "usage"] }
 dotenvy = { workspace = true }
-ferroid-tonic-core = { version = "0.5.3", path = "../ferroid-tonic-core" }
+ferroid-tonic-core = { version = "0.5.4", path = "../ferroid-tonic-core" }
 futures = { workspace = true }
 mimalloc = { workspace = true }
 opentelemetry = { workspace = true, optional = true }

--- a/crates/ferroid/README.md
+++ b/crates/ferroid/README.md
@@ -351,7 +351,7 @@ The $\ln 2$ term arises because $\ln(0.5) = -\ln 2$. After $T_\text{50\%}$ milli
 
 ### Serialize as padded string
 
-Use `.to_padded_string()` or `.encode()` for sortable string representations:
+Use `.encode()` or `.encode_to_buf()` for sortable string representations:
 
 ```rust
 #[cfg(all(feature = "base32", feature = "snowflake"))]
@@ -360,7 +360,6 @@ Use `.to_padded_string()` or `.encode()` for sortable string representations:
 
     let id = SnowflakeTwitterId::from(123456, 1, 42);
     assert_eq!(format!("default: {id}"), "default: 517811998762");
-    assert_eq!(format!("padded: {}", id.to_padded_string()), "padded: 00000000517811998762");
 
     let encoded = id.encode();
     assert_eq!(format!("base32: {encoded}"), "base32: 00000F280041A");
@@ -375,7 +374,6 @@ Use `.to_padded_string()` or `.encode()` for sortable string representations:
 
     let id = ULID::from(123456, 42);
     assert_eq!(format!("default: {id}"), "default: 149249145986343659392525664298");
-    assert_eq!(format!("padded: {}", id.to_padded_string()), "padded: 000000000149249145986343659392525664298");
 
     let encoded = id.encode();
     assert_eq!(format!("base32: {encoded}"), "base32: 0000003RJ0000000000000001A");

--- a/crates/ferroid/benches/bench.rs
+++ b/crates/ferroid/benches/bench.rs
@@ -487,26 +487,61 @@ where
         ID::max_machine_id(),
         ID::max_sequence(),
     );
-    let encoded = id.encode();
-    let mut buf = <ID::Ty as BeBytes>::Base32Array::default();
+    let mut buf = ID::buf();
 
     let mut group = c.benchmark_group(group_name);
     group.throughput(Throughput::Elements(1));
 
-    group.bench_function("encode/string", |b| {
+    group.bench_function("encode/to_string", |b| {
         b.iter(|| {
-            black_box(id.encode());
+            black_box(id.encode().to_string());
         });
     });
-    group.bench_function("encode/buffer", |b| {
+    group.bench_function("encode/as_str", |b| {
         b.iter(|| {
-            id.encode_to_buf(black_box(&mut buf));
-            black_box(());
+            black_box(id.encode().as_str());
         });
     });
-    group.bench_function("decode", |b| {
+    group.bench_function("encode/format", |b| {
         b.iter(|| {
-            black_box(ID::decode(black_box(&encoded)).unwrap());
+            black_box(format!("{}", id.encode()));
+        });
+    });
+    group.bench_function("encode/buffer/to_string", |b| {
+        b.iter(|| {
+            let b = id.encode_to_buf(black_box(&mut buf));
+            black_box(b.to_string());
+        });
+    });
+    group.bench_function("encode/buffer/as_str", |b| {
+        b.iter(|| {
+            let b = id.encode_to_buf(black_box(&mut buf));
+            black_box(b.as_str());
+        });
+    });
+    group.bench_function("encode/buffer/format", |b| {
+        b.iter(|| {
+            let b = id.encode_to_buf(black_box(&mut buf));
+            black_box(format!("{}", b));
+        });
+    });
+
+    let encoded = id.encode();
+    let encoded_str = encoded.as_str();
+    let encoded_string = encoded.to_string();
+    group.bench_function("decode/as_ref", |b| {
+        b.iter(|| {
+            black_box(ID::decode(black_box(encoded.as_ref())).unwrap());
+        });
+    });
+    group.bench_function("decode/str", |b| {
+        b.iter(|| {
+            black_box(ID::decode(black_box(encoded_str)).unwrap());
+        });
+    });
+    group.bench_function("decode/string", |b| {
+        b.iter(|| {
+            black_box(ID::decode(black_box(&encoded_string)).unwrap());
         });
     });
 
@@ -519,26 +554,61 @@ where
     ID::Ty: BeBytes,
 {
     let id = ID::from_components(ID::max_timestamp(), ID::max_random());
-    let encoded = id.encode();
-    let mut buf = <ID::Ty as BeBytes>::Base32Array::default();
+    let mut buf = ID::buf();
 
     let mut group = c.benchmark_group(group_name);
     group.throughput(Throughput::Elements(1));
 
-    group.bench_function("encode/string", |b| {
+    group.bench_function("encode/to_string", |b| {
         b.iter(|| {
-            black_box(id.encode());
+            black_box(id.encode().to_string());
         });
     });
-    group.bench_function("encode/buffer", |b| {
+    group.bench_function("encode/as_str", |b| {
         b.iter(|| {
-            id.encode_to_buf(black_box(&mut buf));
-            black_box(());
+            black_box(id.encode().as_str());
         });
     });
-    group.bench_function("decode", |b| {
+    group.bench_function("encode/format", |b| {
         b.iter(|| {
-            black_box(ID::decode(black_box(&encoded)).unwrap());
+            black_box(format!("{}", id.encode()));
+        });
+    });
+    group.bench_function("encode/buffer/to_string", |b| {
+        b.iter(|| {
+            let b = id.encode_to_buf(black_box(&mut buf));
+            black_box(b.to_string());
+        });
+    });
+    group.bench_function("encode/buffer/as_str", |b| {
+        b.iter(|| {
+            let b = id.encode_to_buf(black_box(&mut buf));
+            black_box(b.as_str());
+        });
+    });
+    group.bench_function("encode/buffer/format", |b| {
+        b.iter(|| {
+            let b = id.encode_to_buf(black_box(&mut buf));
+            black_box(format!("{}", b));
+        });
+    });
+
+    let encoded = id.encode();
+    let encoded_str = encoded.as_str();
+    let encoded_string = encoded.to_string();
+    group.bench_function("decode/as_ref", |b| {
+        b.iter(|| {
+            black_box(ID::decode(black_box(encoded.as_ref())).unwrap());
+        });
+    });
+    group.bench_function("decode/str", |b| {
+        b.iter(|| {
+            black_box(ID::decode(black_box(encoded_str)).unwrap());
+        });
+    });
+    group.bench_function("decode/string", |b| {
+        b.iter(|| {
+            black_box(ID::decode(black_box(&encoded_string)).unwrap());
         });
     });
 

--- a/crates/ferroid/src/base32/be_bytes.rs
+++ b/crates/ferroid/src/base32/be_bytes.rs
@@ -1,3 +1,5 @@
+use std::hash::Hash;
+
 const fn base32_size(bytes: usize) -> usize {
     (bytes * 8).div_ceil(5)
 }
@@ -6,8 +8,26 @@ const fn base32_size(bytes: usize) -> usize {
 pub trait BeBytes: Sized {
     const SIZE: usize;
     const BASE32_SIZE: usize;
-    type ByteArray: AsRef<[u8]> + AsMut<[u8]> + Default + Copy;
-    type Base32Array: AsRef<[u8]> + AsMut<[u8]> + Default + Copy;
+    type ByteArray: AsRef<[u8]>
+        + AsMut<[u8]>
+        + core::fmt::Debug
+        + Default
+        + Copy
+        + PartialEq
+        + Eq
+        + PartialOrd
+        + Ord
+        + Hash;
+    type Base32Array: AsRef<[u8]>
+        + AsMut<[u8]>
+        + core::fmt::Debug
+        + Default
+        + Copy
+        + PartialEq
+        + Eq
+        + PartialOrd
+        + Ord
+        + Hash;
 
     fn to_be_bytes(self) -> Self::ByteArray;
     fn from_be_bytes(bytes: Self::ByteArray) -> Self;

--- a/crates/ferroid/src/base32/mod.rs
+++ b/crates/ferroid/src/base32/mod.rs
@@ -11,7 +11,6 @@ mod ulid;
 pub use be_bytes::*;
 use crockford::*;
 pub use error::*;
-pub use interface::*;
 #[cfg(feature = "snowflake")]
 pub use snowflake::*;
 #[cfg(feature = "ulid")]

--- a/crates/ferroid/src/base32/snowflake.rs
+++ b/crates/ferroid/src/base32/snowflake.rs
@@ -1,4 +1,7 @@
-use crate::{Base32Error, Base32Ext, BeBytes, Error, Id, Result, Snowflake};
+use super::interface::Base32Ext;
+use crate::{Base32Error, BeBytes, Error, Id, Result, Snowflake};
+use core::fmt;
+use core::marker::PhantomData;
 
 /// Extension trait for types that support Crockford Base32 encoding and
 /// decoding.
@@ -21,6 +24,18 @@ pub trait Base32SnowExt: Snowflake
 where
     Self::Ty: BeBytes,
 {
+    /// Allocates a default, zero-initialized buffer for Base32 encoding.
+    ///
+    /// This is a convenience method that returns a [`BeBytes::Base32Array`]
+    /// suitable for use with [`Base32SnowExt::encode_to_buf`]. The returned
+    /// buffer is stack-allocated, has a fixed size known at compile time, and
+    /// is guaranteed to match the Crockford Base32 output size for the backing
+    /// integer type.
+    ///
+    /// See also: [`Base32SnowExt::encode_to_buf`] for usage.
+    fn buf() -> <<Self as Id>::Ty as BeBytes>::Base32Array {
+        <Self as Base32Ext>::inner_buf()
+    }
     /// Encodes this ID into a [`String`] using Crockford Base32.
     ///
     /// The resulting string is guaranteed to be ASCII and lexicographically
@@ -37,8 +52,8 @@ where
     ///     assert_eq!(encoded, "23953MG16DJDJ");
     /// }
     /// ```
-    fn encode(&self) -> String {
-        Self::enc(self)
+    fn encode(&self) -> Base32SnowFormatter<Self> {
+        Base32SnowFormatter::new(self)
     }
     /// Encodes this ID into the provided output buffer without heap allocation.
     ///
@@ -54,9 +69,11 @@ where
     /// {   
     ///     use ferroid::{Base32SnowExt, BeBytes, Id, SnowflakeTwitterId};
     ///     let id = SnowflakeTwitterId::from_raw(2_424_242_424_242_424_242);
+    ///
     ///     // Allocate a zeroed, stack-based buffer with the exact size required for encoding.
-    ///     let mut buf = <<SnowflakeTwitterId as Id>::Ty as BeBytes>::Base32Array::default();
+    ///     let mut buf = SnowflakeTwitterId::buf();
     ///     id.encode_to_buf(&mut buf);
+    ///
     ///     // SAFETY: Crockford Base32 is guaranteed to produce valid ASCII
     ///     let encoded = unsafe { core::str::from_utf8_unchecked(buf.as_ref()) };
     ///     assert_eq!(encoded, "23953MG16DJDJ");
@@ -64,8 +81,11 @@ where
     /// ```
     ///
     /// See also: [`Base32SnowExt::encode`] for an allocation-producing version.
-    fn encode_to_buf(&self, buf: &mut <<Self as Id>::Ty as BeBytes>::Base32Array) {
-        Self::enc_to_buf(self, buf);
+    fn encode_to_buf<'buf>(
+        &self,
+        buf: &'buf mut <<Self as Id>::Ty as BeBytes>::Base32Array,
+    ) -> Base32SnowFormatterRef<'buf, Self> {
+        Base32SnowFormatterRef::new(self, buf)
     }
     /// Decodes a Base32-encoded string back into an ID.
     ///
@@ -132,8 +152,8 @@ where
     ///     }
     /// }
     /// ```
-    fn decode(s: &str) -> Result<Self> {
-        let decoded = Self::dec(s)?;
+    fn decode(s: impl AsRef<str>) -> Result<Self> {
+        let decoded = Self::inner_decode(s)?;
         if !decoded.is_valid() {
             return Err(Error::Base32Error(Base32Error::DecodeOverflow(
                 decoded.to_raw().to_be_bytes().as_ref().to_vec(),
@@ -148,6 +168,160 @@ where
     ID: Snowflake,
     ID::Ty: BeBytes,
 {
+}
+
+/// A reusable builder that owns the Base32 buffer and formats an ID.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Base32SnowFormatter<T>
+where
+    T: Base32SnowExt,
+    T::Ty: BeBytes,
+{
+    _id: PhantomData<T>,
+    buf: <T::Ty as BeBytes>::Base32Array,
+}
+
+impl<T: Base32SnowExt> Base32SnowFormatter<T>
+where
+    T::Ty: BeBytes,
+{
+    pub fn new(id: &T) -> Self {
+        let mut buf = T::buf();
+        id.inner_encode_to_buf(&mut buf);
+        Self {
+            _id: PhantomData,
+            buf,
+        }
+    }
+
+    /// Returns a `&str` view of the base32 encoding.
+    pub fn as_str(&self) -> &str {
+        unsafe { core::str::from_utf8_unchecked(self.buf.as_ref()) }
+    }
+
+    /// Returns an allocated `String` of the base32 encoding.
+    pub fn to_string(&self) -> String {
+        unsafe { String::from_utf8_unchecked(self.buf.as_ref().to_vec()) }
+    }
+
+    /// Consumes the builder and returns the raw buffer.
+    pub fn into_inner(self) -> <T::Ty as BeBytes>::Base32Array {
+        self.buf
+    }
+}
+
+impl<T: Base32SnowExt> fmt::Display for Base32SnowFormatter<T>
+where
+    T::Ty: BeBytes,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl<T: Base32SnowExt> AsRef<str> for Base32SnowFormatter<T>
+where
+    T::Ty: BeBytes,
+{
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl<T: Base32SnowExt> PartialEq<&str> for Base32SnowFormatter<T>
+where
+    T::Ty: BeBytes,
+{
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
+    }
+}
+
+impl<T: Base32SnowExt> PartialEq<String> for Base32SnowFormatter<T>
+where
+    T::Ty: BeBytes,
+{
+    fn eq(&self, other: &String) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+/// A builder that borrows a user-supplied buffer for Base32 formatting.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Base32SnowFormatterRef<'a, T>
+where
+    T: Base32SnowExt,
+    T::Ty: BeBytes,
+{
+    _id: PhantomData<T>,
+    buf: &'a <T::Ty as BeBytes>::Base32Array,
+}
+
+impl<'a, T: Base32SnowExt> Base32SnowFormatterRef<'a, T>
+where
+    T::Ty: BeBytes,
+{
+    pub fn new(id: &T, buf: &'a mut <T::Ty as BeBytes>::Base32Array) -> Self {
+        id.inner_encode_to_buf(buf);
+        Self {
+            _id: PhantomData,
+            buf,
+        }
+    }
+
+    /// Returns a `&str` view of the base32 encoding.
+    pub fn as_str(&self) -> &str {
+        unsafe { core::str::from_utf8_unchecked(self.buf.as_ref()) }
+    }
+
+    /// Returns an allocated `String` of the base32 encoding.
+    pub fn to_string(&self) -> String {
+        unsafe { String::from_utf8_unchecked(self.buf.as_ref().to_vec()) }
+    }
+}
+
+impl<'a, T: Base32SnowExt> fmt::Display for Base32SnowFormatterRef<'a, T>
+where
+    T::Ty: BeBytes,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl<'a, T: Base32SnowExt> AsRef<str> for Base32SnowFormatterRef<'a, T>
+where
+    T::Ty: BeBytes,
+{
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl<'a, T: Base32SnowExt> PartialEq<str> for Base32SnowFormatterRef<'a, T>
+where
+    T::Ty: BeBytes,
+{
+    fn eq(&self, other: &str) -> bool {
+        self.as_str() == other
+    }
+}
+impl<'a, T: Base32SnowExt> PartialEq<&str> for Base32SnowFormatterRef<'a, T>
+where
+    T::Ty: BeBytes,
+{
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
+    }
+}
+
+impl<'a, T: Base32SnowExt> PartialEq<String> for Base32SnowFormatterRef<'a, T>
+where
+    T::Ty: BeBytes,
+{
+    fn eq(&self, other: &String) -> bool {
+        self.as_str() == other.as_str()
+    }
 }
 
 #[cfg(all(test, feature = "snowflake"))]
@@ -170,7 +344,7 @@ mod test {
 
         let encoded = id.encode();
         assert_eq!(encoded, "7ZZZZZZZZZZZZ");
-        let decoded = SnowflakeTwitterId::decode(&encoded).unwrap();
+        let decoded = SnowflakeTwitterId::decode(encoded).unwrap();
 
         assert_eq!(decoded.timestamp(), SnowflakeTwitterId::max_timestamp());
         assert_eq!(decoded.machine_id(), SnowflakeTwitterId::max_machine_id());
@@ -187,7 +361,7 @@ mod test {
 
         let encoded = id.encode();
         assert_eq!(encoded, "0000000000000");
-        let decoded = SnowflakeTwitterId::decode(&encoded).unwrap();
+        let decoded = SnowflakeTwitterId::decode(encoded).unwrap();
 
         assert_eq!(decoded.timestamp(), 0);
         assert_eq!(decoded.machine_id(), 0);
@@ -208,7 +382,7 @@ mod test {
 
         let encoded = id.encode();
         assert_eq!(encoded, "FZZZZZZZZZZZZ");
-        let decoded = SnowflakeDiscordId::decode(&encoded).unwrap();
+        let decoded = SnowflakeDiscordId::decode(encoded).unwrap();
 
         assert_eq!(decoded.timestamp(), SnowflakeDiscordId::max_timestamp());
         assert_eq!(decoded.machine_id(), SnowflakeDiscordId::max_machine_id());
@@ -225,7 +399,7 @@ mod test {
 
         let encoded = id.encode();
         assert_eq!(encoded, "0000000000000");
-        let decoded = SnowflakeDiscordId::decode(&encoded).unwrap();
+        let decoded = SnowflakeDiscordId::decode(encoded).unwrap();
 
         assert_eq!(decoded.timestamp(), 0);
         assert_eq!(decoded.machine_id(), 0);
@@ -246,7 +420,7 @@ mod test {
 
         let encoded = id.encode();
         assert_eq!(encoded, "FZZZZZZZZZZZZ");
-        let decoded = SnowflakeInstagramId::decode(&encoded).unwrap();
+        let decoded = SnowflakeInstagramId::decode(encoded).unwrap();
 
         assert_eq!(decoded.timestamp(), SnowflakeInstagramId::max_timestamp());
         assert_eq!(decoded.machine_id(), SnowflakeInstagramId::max_machine_id());
@@ -263,7 +437,7 @@ mod test {
 
         let encoded = id.encode();
         assert_eq!(encoded, "0000000000000");
-        let decoded = SnowflakeInstagramId::decode(&encoded).unwrap();
+        let decoded = SnowflakeInstagramId::decode(encoded).unwrap();
 
         assert_eq!(decoded.timestamp(), 0);
         assert_eq!(decoded.machine_id(), 0);
@@ -284,7 +458,7 @@ mod test {
 
         let encoded = id.encode();
         assert_eq!(encoded, "FZZZZZZZZZZZZ");
-        let decoded = SnowflakeMastodonId::decode(&encoded).unwrap();
+        let decoded = SnowflakeMastodonId::decode(encoded).unwrap();
 
         assert_eq!(decoded.timestamp(), SnowflakeMastodonId::max_timestamp());
         assert_eq!(decoded.machine_id(), SnowflakeMastodonId::max_machine_id());
@@ -301,7 +475,7 @@ mod test {
 
         let encoded = id.encode();
         assert_eq!(encoded, "0000000000000");
-        let decoded = SnowflakeMastodonId::decode(&encoded).unwrap();
+        let decoded = SnowflakeMastodonId::decode(encoded).unwrap();
 
         assert_eq!(decoded.timestamp(), 0);
         assert_eq!(decoded.machine_id(), 0);

--- a/crates/ferroid/src/base32/ulid.rs
+++ b/crates/ferroid/src/base32/ulid.rs
@@ -1,4 +1,7 @@
-use crate::{Base32Error, Base32Ext, BeBytes, Error, Id, Result, Ulid};
+use super::interface::Base32Ext;
+use crate::{Base32Error, BeBytes, Error, Id, Result, Ulid};
+use core::fmt;
+use core::marker::PhantomData;
 
 /// Extension trait for types that support Crockford Base32 encoding and
 /// decoding.
@@ -21,6 +24,18 @@ pub trait Base32UlidExt: Ulid
 where
     Self::Ty: BeBytes,
 {
+    /// Allocates a default, zero-initialized buffer for Base32 encoding.
+    ///
+    /// This is a convenience method that returns a [`BeBytes::Base32Array`]
+    /// suitable for use with [`Base32UlidExt::encode_to_buf`]. The returned
+    /// buffer is stack-allocated, has a fixed size known at compile time, and
+    /// is guaranteed to match the Crockford Base32 output size for the backing
+    /// integer type.
+    ///
+    /// See also: [`Base32UlidExt::encode_to_buf`] for usage.
+    fn buf() -> <<Self as Id>::Ty as BeBytes>::Base32Array {
+        <Self as Base32Ext>::inner_buf()
+    }
     /// Encodes this ID into a [`String`] using Crockford Base32.
     ///
     /// The resulting string is guaranteed to be ASCII and lexicographically
@@ -37,8 +52,8 @@ where
     ///     assert_eq!(encoded, "000000000000023953MG16DJDJ");
     /// }
     /// ```
-    fn encode(&self) -> String {
-        Self::enc(self)
+    fn encode(&self) -> Base32UlidFormatter<Self> {
+        Base32UlidFormatter::new(self)
     }
     /// Encodes this ID into the provided output buffer without heap allocation.
     ///
@@ -56,7 +71,7 @@ where
     ///     let id = ULID::from_raw(2_424_242_424_242_424_242);
     ///
     ///     // Allocate a zeroed, stack-based buffer with the exact size required for encoding.
-    ///     let mut buf = <<ULID as Id>::Ty as BeBytes>::Base32Array::default();
+    ///     let mut buf = ULID::buf();
     ///     id.encode_to_buf(&mut buf);
     ///
     ///     // SAFETY: Crockford Base32 is guaranteed to produce valid ASCII
@@ -66,8 +81,11 @@ where
     /// ```
     ///
     /// See also: [`Base32UlidExt::encode`] for an allocation-producing version.
-    fn encode_to_buf(&self, buf: &mut <<Self as Id>::Ty as BeBytes>::Base32Array) {
-        Self::enc_to_buf(self, buf);
+    fn encode_to_buf<'buf>(
+        &self,
+        buf: &'buf mut <<Self as Id>::Ty as BeBytes>::Base32Array,
+    ) -> Base32UlidFormatterRef<'buf, Self> {
+        Base32UlidFormatterRef::new(self, buf)
     }
     /// Decodes a Base32-encoded string back into an ID.
     ///
@@ -76,8 +94,8 @@ where
     /// integer representing a ULID, regardless of whether the input is a
     /// canonical ULID.
     ///
-    /// - If the input string's Crockford encoding is larger than
-    ///   the ULID spec's maximum (i.e. "7ZZZZZZZZZZZZZZZZZZZZZZZZZ" for 128-bit
+    /// - If the input string's Crockford encoding is larger than the ULID
+    ///   spec's maximum (i.e. "7ZZZZZZZZZZZZZZZZZZZZZZZZZ" for 128-bit
     ///   integers), the excess bits are automatically truncated (i.e., the top
     ///   2 bits of the decoded value are discarded), so no overflow or error
     ///   occurs.
@@ -118,8 +136,8 @@ where
     ///     assert!(ULID::decode("ZZZZZZZZZZZZZZZZZZZZZZZZZZ").is_ok());
     /// }
     /// ```
-    fn decode(s: &str) -> Result<Self> {
-        let decoded = Self::dec(s)?;
+    fn decode(s: impl AsRef<str>) -> Result<Self> {
+        let decoded = Self::inner_decode(s)?;
         if !decoded.is_valid() {
             return Err(Error::Base32Error(Base32Error::DecodeOverflow(
                 decoded.to_raw().to_be_bytes().as_ref().to_vec(),
@@ -134,6 +152,160 @@ where
     ID: Ulid,
     ID::Ty: BeBytes,
 {
+}
+
+/// A reusable builder that owns the Base32 buffer and formats an ID.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Base32UlidFormatter<T>
+where
+    T: Base32UlidExt,
+    T::Ty: BeBytes,
+{
+    _id: PhantomData<T>,
+    buf: <T::Ty as BeBytes>::Base32Array,
+}
+
+impl<T: Base32UlidExt> Base32UlidFormatter<T>
+where
+    T::Ty: BeBytes,
+{
+    pub fn new(id: &T) -> Self {
+        let mut buf = T::buf();
+        id.inner_encode_to_buf(&mut buf);
+        Self {
+            _id: PhantomData,
+            buf,
+        }
+    }
+
+    /// Returns a `&str` view of the base32 encoding.
+    pub fn as_str(&self) -> &str {
+        unsafe { core::str::from_utf8_unchecked(self.buf.as_ref()) }
+    }
+
+    /// Returns an allocated `String` of the base32 encoding.
+    pub fn to_string(&self) -> String {
+        unsafe { String::from_utf8_unchecked(self.buf.as_ref().to_vec()) }
+    }
+
+    /// Consumes the builder and returns the raw buffer.
+    pub fn into_inner(self) -> <T::Ty as BeBytes>::Base32Array {
+        self.buf
+    }
+}
+
+impl<T: Base32UlidExt> fmt::Display for Base32UlidFormatter<T>
+where
+    T::Ty: BeBytes,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl<T: Base32UlidExt> AsRef<str> for Base32UlidFormatter<T>
+where
+    T::Ty: BeBytes,
+{
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl<T: Base32UlidExt> PartialEq<&str> for Base32UlidFormatter<T>
+where
+    T::Ty: BeBytes,
+{
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
+    }
+}
+
+impl<T: Base32UlidExt> PartialEq<String> for Base32UlidFormatter<T>
+where
+    T::Ty: BeBytes,
+{
+    fn eq(&self, other: &String) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+/// A builder that borrows a user-supplied buffer for Base32 formatting.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Base32UlidFormatterRef<'a, T>
+where
+    T: Base32UlidExt,
+    T::Ty: BeBytes,
+{
+    _id: PhantomData<T>,
+    buf: &'a <T::Ty as BeBytes>::Base32Array,
+}
+
+impl<'a, T: Base32UlidExt> Base32UlidFormatterRef<'a, T>
+where
+    T::Ty: BeBytes,
+{
+    pub fn new(id: &T, buf: &'a mut <T::Ty as BeBytes>::Base32Array) -> Self {
+        id.inner_encode_to_buf(buf);
+        Self {
+            _id: PhantomData,
+            buf,
+        }
+    }
+
+    /// Returns a `&str` view of the base32 encoding.
+    pub fn as_str(&self) -> &str {
+        unsafe { core::str::from_utf8_unchecked(self.buf.as_ref()) }
+    }
+
+    /// Returns an allocated `String` of the base32 encoding.
+    pub fn to_string(&self) -> String {
+        unsafe { String::from_utf8_unchecked(self.buf.as_ref().to_vec()) }
+    }
+}
+
+impl<'a, T: Base32UlidExt> fmt::Display for Base32UlidFormatterRef<'a, T>
+where
+    T::Ty: BeBytes,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl<'a, T: Base32UlidExt> AsRef<str> for Base32UlidFormatterRef<'a, T>
+where
+    T::Ty: BeBytes,
+{
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl<'a, T: Base32UlidExt> PartialEq<str> for Base32UlidFormatterRef<'a, T>
+where
+    T::Ty: BeBytes,
+{
+    fn eq(&self, other: &str) -> bool {
+        self.as_str() == other
+    }
+}
+impl<'a, T: Base32UlidExt> PartialEq<&str> for Base32UlidFormatterRef<'a, T>
+where
+    T::Ty: BeBytes,
+{
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
+    }
+}
+
+impl<'a, T: Base32UlidExt> PartialEq<String> for Base32UlidFormatterRef<'a, T>
+where
+    T::Ty: BeBytes,
+{
+    fn eq(&self, other: &String) -> bool {
+        self.as_str() == other.as_str()
+    }
 }
 
 #[cfg(all(test, feature = "ulid"))]
@@ -163,7 +335,7 @@ mod test {
 
         let encoded = id.encode();
         assert_eq!(encoded, "01ARZ3NDEKTSV4RRFFQ69G5FAV");
-        let decoded = ULID::decode(&encoded).unwrap();
+        let decoded = ULID::decode(encoded).unwrap();
 
         assert_eq!(decoded.timestamp(), 1469922850259);
         assert_eq!(decoded.random(), 1012768647078601740696923);
@@ -175,7 +347,7 @@ mod test {
 
         let encoded = id.encode();
         assert_eq!(encoded, "01EWW6K6EXQDX5JV0E9CAHPXG5");
-        let decoded = ULID::decode(&encoded).unwrap();
+        let decoded = ULID::decode(encoded).unwrap();
 
         assert_eq!(decoded.timestamp(), 1611559180765);
         assert_eq!(decoded.random(), 885339478614498720052741);

--- a/crates/ferroid/src/id/snowflake.rs
+++ b/crates/ferroid/src/id/snowflake.rs
@@ -69,8 +69,6 @@ pub trait Snowflake:
     /// Returns a normalized version of the ID with any invalid or reserved bits
     /// cleared. This guarantees a valid, canonical representation.
     fn into_valid(self) -> Self;
-
-    fn to_padded_string(&self) -> String;
 }
 
 /// # Field Ordering Semantics
@@ -269,17 +267,6 @@ macro_rules! define_snowflake_id {
                 let raw = self.to_raw() & Self::valid_mask();
                 Self::from_raw(raw)
             }
-
-            fn to_padded_string(&self) -> String {
-                let max = Self::Ty::MAX;
-                let mut n = max;
-                let mut digits = 1;
-                while n >= 10 {
-                    n /= 10;
-                    digits += 1;
-                }
-                format!("{:0width$}", self.to_raw(), width = digits)
-            }
         }
 
         impl core::fmt::Display for $name {
@@ -290,13 +277,10 @@ macro_rules! define_snowflake_id {
 
         impl core::fmt::Debug for $name {
             fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                use $crate::Snowflake;
-
                 let full = core::any::type_name::<Self>();
                 let name = full.rsplit("::").next().unwrap_or(full);
                 let mut dbg = f.debug_struct(name);
                 dbg.field("id", &format_args!("{:} (0x{:x})", self.to_raw(), self.to_raw()));
-                dbg.field("padded", &self.to_padded_string());
                 dbg.field("timestamp", &format_args!("{:} (0x{:x})", self.timestamp(), self.timestamp()));
                 dbg.field("machine_id", &format_args!("{:} (0x{:x})", self.machine_id(), self.machine_id()));
                 dbg.field("sequence", &format_args!("{:} (0x{:x})", self.sequence(), self.sequence()));

--- a/crates/ferroid/src/id/ulid.rs
+++ b/crates/ferroid/src/id/ulid.rs
@@ -54,8 +54,6 @@ pub trait Ulid:
     /// Returns a normalized version of the ID with any invalid or reserved bits
     /// cleared. This guarantees a valid, canonical representation.
     fn into_valid(self) -> Self;
-
-    fn to_padded_string(&self) -> String;
 }
 
 /// # Field Ordering Semantics
@@ -277,17 +275,6 @@ macro_rules! define_ulid {
                 let raw = self.to_raw() & Self::valid_mask();
                 Self::from_raw(raw)
             }
-
-            fn to_padded_string(&self) -> String {
-                let max = Self::Ty::MAX;
-                let mut n = max;
-                let mut digits = 1;
-                while n >= 10 {
-                    n /= 10;
-                    digits += 1;
-                }
-                format!("{:0width$}", self.to_raw(), width = digits)
-            }
         }
 
         impl core::fmt::Display for $name {
@@ -298,13 +285,10 @@ macro_rules! define_ulid {
 
         impl core::fmt::Debug for $name {
             fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                use $crate::Ulid;
-
                 let full = core::any::type_name::<Self>();
                 let name = full.rsplit("::").next().unwrap_or(full);
                 let mut dbg = f.debug_struct(name);
                 dbg.field("id", &format_args!("{:} (0x{:x})", self.to_raw(), self.to_raw()));
-                dbg.field("padded", &self.to_padded_string());
                 dbg.field("timestamp", &format_args!("{:} (0x{:x})", self.timestamp(), self.timestamp()));
                 dbg.field("random", &format_args!("{:} (0x{:x})", self.random(), self.random()));
                 dbg.finish()


### PR DESCRIPTION
This PR introduces a new-type pattern for, zero-allocation Base32 formatting API for both `Snowflake` and `Ulid` types.

 ## New Breaking Changes

The previous `encode` and `encode_to_buf` methods now return:
- `Base32SnowFormatter` / `Base32SnowFormatterRef`
- `Base32UlidFormatter` / `Base32UlidFormatterRef`

The owned variants internally allocate a stack-based buffer, while the *Ref variants borrow a caller-supplied buffer to avoid heap allocation. Both forms eagerly encode during construction.

The key change is how formatting is handled: instead of allocating a String or returning a raw &str, the new formatters implement traits like Display, ToString, and AsRef<str>, letting the caller decide how to consume them. This avoids unnecessary allocations in contexts like logging, serialization, or string formatting. 

They also implement convenient comparison and hashing traits: PartialEq, Eq, PartialOrd, Ord, and Hash, allowing direct use in comparisons and as map/set keys without further allocation.

## Other Breaking Changes
Removed public access to the `Base32Ext` trait to eliminate a footgun - specifically, it would allow decoding into ID types while ignoring reserved bits (which is now handled in the `Base32SnowExt` and `Base32UlidExt` traits respectively.

Removed all `.to_padded_string()` methods from ID types. These were redundant with Debug and introduced unnecessary heap allocation.
