### PR TITLE
More ergonomic thread local `UlidMono`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,7 +594,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferroid"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "async-lock",
  "base32",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "ferroid-tonic-core"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "ferroid",
  "prost",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "ferroid-tonic-server"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.4"
+version = "0.5.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Nick Angelou <angelou.nick@gmail.com>"]

--- a/crates/ferroid-tonic-core/Cargo.toml
+++ b/crates/ferroid-tonic-core/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 publish = true
 
 [dependencies]
-ferroid = { version = "0.5.4", path = "../ferroid", features = ["snowflake", "ulid"] }
+ferroid = { version = "0.5.5", path = "../ferroid", features = ["snowflake", "ulid"] }
 prost = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tonic = { workspace = true, features = ["prost", "codegen"] }

--- a/crates/ferroid-tonic-server/Cargo.toml
+++ b/crates/ferroid-tonic-server/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = { workspace = true, features = ["std"] }
 bytes = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "color", "error-context", "help", "std", "suggestions", "usage"] }
 dotenvy = { workspace = true }
-ferroid-tonic-core = { version = "0.5.4", path = "../ferroid-tonic-core" }
+ferroid-tonic-core = { version = "0.5.5", path = "../ferroid-tonic-core" }
 futures = { workspace = true }
 mimalloc = { workspace = true }
 opentelemetry = { workspace = true, optional = true }

--- a/crates/ferroid/benches/bench.rs
+++ b/crates/ferroid/benches/bench.rs
@@ -148,13 +148,12 @@ fn bench_generator_threaded<ID, G, T>(
                                             }
                                             IdGenStatus::Pending { yield_for } => {
                                                 std::thread::sleep(Duration::from_millis(
-                                                    yield_for.to_u64()?,
+                                                    yield_for.to_u64(),
                                                 ));
                                             }
                                         }
                                     }
                                 }
-                                Ok::<(), Error>(())
                             });
                         }
                     })
@@ -349,13 +348,12 @@ fn bench_generator_ulid_threaded<ID, G, T, R>(
                                             }
                                             IdGenStatus::Pending { yield_for } => {
                                                 std::thread::sleep(Duration::from_millis(
-                                                    yield_for.to_u64()?,
+                                                    yield_for.to_u64(),
                                                 ));
                                             }
                                         }
                                     }
                                 }
-                                Ok::<(), Error>(())
                             });
                         }
                     })

--- a/crates/ferroid/benches/bench.rs
+++ b/crates/ferroid/benches/bench.rs
@@ -3,7 +3,7 @@ use core::time::Duration;
 use criterion::async_executor::SmolExecutor;
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use ferroid::{
-    AtomicSnowflakeGenerator, Backoff, Base32SnowExt, Base32UlidExt, BasicSnowflakeGenerator,
+    AtomicSnowflakeGenerator, Base32SnowExt, Base32UlidExt, BasicSnowflakeGenerator,
     BasicUlidGenerator, BeBytes, Error, Id, IdGenStatus, LockSnowflakeGenerator, LockUlidGenerator,
     MonotonicClock, RandSource, SmolSleep, Snowflake, SnowflakeGenerator,
     SnowflakeGeneratorAsyncExt, SnowflakeMastodonId, SnowflakeTwitterId, ThreadRandom, TimeSource,
@@ -922,11 +922,11 @@ fn bench_thread_local(c: &mut Criterion) {
 criterion_group!(
     benches,
     // --- Base32 ---
-    // bench_base32,
-    // // --- Clock ---
-    // bench_mono_clock,
-    // // --- RNG ---
-    // bench_thread_rand,
+    bench_base32,
+    // --- Clock ---
+    bench_mono_clock,
+    // --- RNG ---
+    bench_thread_rand,
     // --- Thread locals ---
     bench_thread_local,
     // --- Snowflake ---

--- a/crates/ferroid/src/error.rs
+++ b/crates/ferroid/src/error.rs
@@ -7,7 +7,6 @@ pub type Result<T> = core::result::Result<T, Error>;
 #[non_exhaustive]
 pub enum Error {
     LockPoisoned,
-    FailedToU64,
     #[cfg(feature = "base32")]
     Base32Error(crate::Base32Error),
 }

--- a/crates/ferroid/src/futures/snowflake.rs
+++ b/crates/ferroid/src/futures/snowflake.rs
@@ -118,7 +118,7 @@ where
         match this.generator.try_next_id()? {
             IdGenStatus::Ready { id } => Poll::Ready(Ok(id)),
             IdGenStatus::Pending { yield_for } => {
-                let sleep_fut = S::sleep_for(Duration::from_millis(yield_for.to_u64()?));
+                let sleep_fut = S::sleep_for(Duration::from_millis(yield_for.to_u64()));
                 this.sleep.as_mut().set(Some(sleep_fut));
                 cx.waker().wake_by_ref();
                 Poll::Pending

--- a/crates/ferroid/src/futures/ulid.rs
+++ b/crates/ferroid/src/futures/ulid.rs
@@ -123,7 +123,7 @@ where
         match this.generator.try_next_id()? {
             IdGenStatus::Ready { id } => Poll::Ready(Ok(id)),
             IdGenStatus::Pending { yield_for } => {
-                let sleep_fut = S::sleep_for(Duration::from_millis(yield_for.to_u64()?));
+                let sleep_fut = S::sleep_for(Duration::from_millis(yield_for.to_u64()));
                 this.sleep.as_mut().set(Some(sleep_fut));
                 cx.waker().wake_by_ref();
                 Poll::Pending

--- a/crates/ferroid/src/generator/snowflake/tests.rs
+++ b/crates/ferroid/src/generator/snowflake/tests.rs
@@ -85,12 +85,12 @@ where
     let id2 = generator.next_id().unwrap_ready();
     let id3 = generator.next_id().unwrap_ready();
 
-    assert_eq!(id1.timestamp().to_u64().unwrap(), 42);
-    assert_eq!(id2.timestamp().to_u64().unwrap(), 42);
-    assert_eq!(id3.timestamp().to_u64().unwrap(), 42);
-    assert_eq!(id1.sequence().to_u64().unwrap(), 0);
-    assert_eq!(id2.sequence().to_u64().unwrap(), 1);
-    assert_eq!(id3.sequence().to_u64().unwrap(), 2);
+    assert_eq!(id1.timestamp().to_u64(), 42);
+    assert_eq!(id2.timestamp().to_u64(), 42);
+    assert_eq!(id3.timestamp().to_u64(), 42);
+    assert_eq!(id1.sequence().to_u64(), 0);
+    assert_eq!(id2.sequence().to_u64(), 1);
+    assert_eq!(id3.sequence().to_u64(), 2);
     assert!(id1 < id2 && id2 < id3);
 }
 
@@ -110,10 +110,10 @@ where
     ID: Snowflake,
     T: TimeSource<ID::Ty>,
 {
-    for i in 0..=ID::max_sequence().to_u64().unwrap() {
+    for i in 0..=ID::max_sequence().to_u64() {
         let id = generator.next_id().unwrap_ready();
-        assert_eq!(id.sequence().to_u64().unwrap(), i);
-        assert_eq!(id.timestamp().to_u64().unwrap(), 42);
+        assert_eq!(id.sequence().to_u64(), i);
+        assert_eq!(id.timestamp().to_u64(), 42);
     }
 
     let yield_for = generator.next_id().unwrap_pending();
@@ -122,8 +122,8 @@ where
     shared_time.clock.index.set(1);
 
     let id = generator.next_id().unwrap_ready();
-    assert_eq!(id.timestamp().to_u64().unwrap(), 43);
-    assert_eq!(id.sequence().to_u64().unwrap(), 0);
+    assert_eq!(id.timestamp().to_u64(), 43);
+    assert_eq!(id.sequence().to_u64(), 0);
 }
 
 fn run_generator_monotonic<G, ID, T>(generator: G)

--- a/crates/ferroid/src/generator/ulid/tests.rs
+++ b/crates/ferroid/src/generator/ulid/tests.rs
@@ -114,12 +114,12 @@ where
     let id2 = generator.next_id().unwrap_ready();
     let id3 = generator.next_id().unwrap_ready();
 
-    assert_eq!(id1.timestamp().to_u64().unwrap(), 42);
-    assert_eq!(id2.timestamp().to_u64().unwrap(), 42);
-    assert_eq!(id3.timestamp().to_u64().unwrap(), 42);
-    assert_eq!(id1.random().to_u64().unwrap(), 42);
-    assert_eq!(id2.random().to_u64().unwrap(), 42 + 1);
-    assert_eq!(id3.random().to_u64().unwrap(), 42 + 2);
+    assert_eq!(id1.timestamp().to_u64(), 42);
+    assert_eq!(id2.timestamp().to_u64(), 42);
+    assert_eq!(id3.timestamp().to_u64(), 42);
+    assert_eq!(id1.random().to_u64(), 42);
+    assert_eq!(id2.random().to_u64(), 42 + 1);
+    assert_eq!(id3.random().to_u64(), 42 + 2);
     assert!(id1 < id2 && id2 < id3);
 }
 
@@ -142,7 +142,7 @@ where
     R: RandSource<ID::Ty>,
 {
     let id = generator.next_id().unwrap_ready();
-    assert_eq!(id.timestamp().to_u64().unwrap(), 42);
+    assert_eq!(id.timestamp().to_u64(), 42);
 
     let yield_for = generator.next_id().unwrap_pending();
     assert_eq!(yield_for, ID::ONE);
@@ -150,7 +150,7 @@ where
     shared_time.clock.index.set(1);
 
     let id = generator.next_id().unwrap_ready();
-    assert_eq!(id.timestamp().to_u64().unwrap(), 43);
+    assert_eq!(id.timestamp().to_u64(), 43);
 }
 
 fn run_generator_monotonic<G, ID, T, R>(generator: G)

--- a/crates/ferroid/src/generator/ulid/thread_local.rs
+++ b/crates/ferroid/src/generator/ulid/thread_local.rs
@@ -61,11 +61,7 @@ fn ulid_mono(strategy: Backoff) -> ULID {
         Backoff::Spin => core::hint::spin_loop(),
         Backoff::Yield => std::thread::yield_now(),
         Backoff::Sleep => {
-            std::thread::sleep(core::time::Duration::from_millis(
-                yield_for
-                    .to_u64()
-                    .expect("ULID timestamp should always fit in u64 (48 bits)"),
-            ));
+            std::thread::sleep(core::time::Duration::from_millis(yield_for.to_u64()));
         }
     })
 }

--- a/crates/ferroid/src/id/to_u64.rs
+++ b/crates/ferroid/src/id/to_u64.rs
@@ -1,40 +1,47 @@
-use crate::{Error, Result};
-
 /// Trait for converting numeric-like values into a `u64`.
 ///
 /// This is typically used to normalize custom duration types into milliseconds
 /// for compatibility with APIs like [`core::time::Duration::from_millis`],
 /// which are commonly required in async sleep contexts.
+///
+/// # Safety and Behavior
+///
+/// For types that may exceed the `u64` range (e.g., `u128`), values that cannot
+/// be losslessly converted will saturate to `u64::MAX`. This avoids propagating
+/// errors in time-sensitive code like ID generation. In such systems, a
+/// fallback to `u64::MAX` is generally safe: it typically causes a retry
+/// without compromising correctness, since most sane ID formats reserve no more
+/// than 48 bits for timestamps - far below the 64-bit boundary.
 pub trait ToU64 {
-    fn to_u64(self) -> Result<u64>;
+    fn to_u64(self) -> u64;
 }
 
 impl ToU64 for u8 {
-    fn to_u64(self) -> Result<u64> {
-        Ok(self as u64)
+    fn to_u64(self) -> u64 {
+        self as u64
     }
 }
 
 impl ToU64 for u16 {
-    fn to_u64(self) -> Result<u64> {
-        Ok(self as u64)
+    fn to_u64(self) -> u64 {
+        self as u64
     }
 }
 
 impl ToU64 for u32 {
-    fn to_u64(self) -> Result<u64> {
-        Ok(self as u64)
+    fn to_u64(self) -> u64 {
+        self as u64
     }
 }
 
 impl ToU64 for u64 {
-    fn to_u64(self) -> Result<u64> {
-        Ok(self)
+    fn to_u64(self) -> u64 {
+        self
     }
 }
 
 impl ToU64 for u128 {
-    fn to_u64(self) -> Result<u64> {
-        self.try_into().map_err(|_| Error::FailedToU64)
+    fn to_u64(self) -> u64 {
+        self.try_into().unwrap_or(u64::MAX)
     }
 }


### PR DESCRIPTION
This PR introduces a new `UlidMono` type to encapsulate thread-local ULID generation with sensible defaults. It mirrors the ergonomics of other libraries and provides a clearer API surface for monotonic ID generation.

Additionally, this PR removes the `Error::FailedToU64` variant. Instead of returning an error when converting a `u128` timestamp to `u64`, we now saturate to `u64::MAX`. This avoids unnecessary errors in time normalization (e.g., when using sleep loops), and in the worst case--attempting to sleep for ~585 million years--simply results in an early retry. This is both safer and more practical, as most ID formats reserve far fewer than 64 bits for timestamp representation.