### PR TITLE
Modular `no_std` Refactor, Feature Gating, and Base32 Improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "async-fs"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
+checksum = "09f7e37c0ed80b2a977691c47dae8625cfb21e205827106c64f7c588766b2e50"
 dependencies = [
  "async-lock",
  "blocking",
@@ -142,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1237c0ae75a0f3765f58910ff9cdd0a12eeb39ab2f4c7de23262f337f0aacbb3"
+checksum = "19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca"
 dependencies = [
  "async-lock",
  "cfg-if",
@@ -155,8 +155,7 @@ dependencies = [
  "polling",
  "rustix",
  "slab",
- "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -183,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde3f4e40e6021d7acffc90095cbd6dc54cb593903d1de5832f435eb274b85dc"
+checksum = "65daa13722ad51e6ab1a1b9c01299142bc75135b337923cfa10e79bbbd669f00"
 dependencies = [
  "async-channel",
  "async-io",
@@ -197,14 +196,13 @@ dependencies = [
  "event-listener",
  "futures-lite",
  "rustix",
- "tracing",
 ]
 
 [[package]]
 name = "async-signal"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7605a4e50d4b06df3898d5a70bf5fde51ed9059b0434b73105193bc27acce0d"
+checksum = "f567af260ef69e1d52c2b560ce0ea230763e6fbb9214a85d768760a920e3e3c1"
 dependencies = [
  "async-io",
  "async-lock",
@@ -215,7 +213,7 @@ dependencies = [
  "rustix",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -358,9 +356,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.29"
+version = "1.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
+checksum = "c3a42d84bb6b69d3a8b3eaacf0d88f179e1929695e1ad012b6cf64d9caaa5fd2"
 dependencies = [
  "jobserver",
  "libc",
@@ -414,9 +412,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.41"
+version = "4.5.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "ed87a9d530bb41a67537289bafcac159cb3ee28460e0a4571123d2a778a6a882"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -424,9 +422,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.5.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "64f4f3f3c77c94aff3c7e9aac9a2ca1974a5adf392a8bb751e827d6d127ab966"
 dependencies = [
  "anstream",
  "anstyle",
@@ -494,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf7af66b0989381bd0be551bd7cc91912a655a58c6918420c9527b1fd8b4679"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
 dependencies = [
  "anes",
  "cast",
@@ -517,12 +515,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -594,7 +592,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferroid"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "async-lock",
  "base32",
@@ -611,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "ferroid-tonic-core"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "ferroid",
  "prost",
@@ -622,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "ferroid-tonic-server"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -929,9 +927,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -942,7 +940,7 @@ dependencies = [
  "hyper",
  "libc",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -984,9 +982,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -998,15 +996,6 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -1397,17 +1386,16 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polling"
-version = "3.8.0"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b53a684391ad002dd6a596ceb6c74fd004fdce75f4be2e3f615068abbea5fd50"
+checksum = "8ee9b2fa7a4517d2c91ff5bc6c297a427a96749d15f98fcdbb22c05571a4d4b7"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
  "rustix",
- "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1421,9 +1409,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
+checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -1507,9 +1495,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1536,9 +1524,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
 ]
@@ -1603,28 +1591,28 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.29"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "log",
  "once_cell",
@@ -1748,9 +1736,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "itoa",
  "memchr",
@@ -1819,6 +1807,16 @@ checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1904,9 +1902,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.46.1"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1917,9 +1915,9 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1990,7 +1988,7 @@ dependencies = [
  "pin-project",
  "prost",
  "rustls-native-certs",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -2441,7 +2439,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -2462,10 +2460,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,9 +56,6 @@ tracing = { version = "0.1", default-features = false }
 tracing-opentelemetry = { version = "0.31", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false }
 
-[profile.dev]
-panic = "abort"
-
 [profile.bin-release]
 inherits = "release"
 codegen-units = 1           # reduce size and help opt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,9 @@ tracing = { version = "0.1", default-features = false }
 tracing-opentelemetry = { version = "0.31", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false }
 
+[profile.dev]
+panic = "abort"
+
 [profile.bin-release]
 inherits = "release"
 codegen-units = 1           # reduce size and help opt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.5"
+version = "0.6.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Nick Angelou <angelou.nick@gmail.com>"]
@@ -23,7 +23,7 @@ axum = { version = "0.8", default-features = false }
 base32 = { version = "0.5", default-features = false }
 bytes = { version = "1.10", default-features = false }
 clap = { version = "4.5", default-features = false }
-criterion = { version = "0.6", default-features = false }
+criterion = { version = "0.7", default-features = false }
 dotenvy = { version = "0.15", default-features = false }
 futures = { version = "0.3", default-features = false }
 hyper = { version = "1.6.0", default-features = false }
@@ -42,7 +42,7 @@ rand = { version = "0.9", default-features = false }
 serde = { version = "1.0", default-features = false }
 smol = { version = "2.0", default-features = false }
 thiserror = { version = "2.0", default-features = false }
-tokio = { version = "1.46", default-features = false }
+tokio = { version = "1.47", default-features = false }
 tokio-stream = { version = "0.1", default-features = false }
 tokio-util = { version = "0.7", default-features = false }
 tonic = { version = "0.13", default-features = false }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ The core library provides:
   - `LockSnowflakeGenerator`: multi-threaded with locking
   - `AtomicSnowflakeGenerator`: multi-threaded, lock-free
   - `BasicUlidGenerator`: single-threaded, high-entropy ULID generation
-  - `LockUlidGenerator`: multi-threaded, high-entropy ULID generation
+  - `BasicMonoUlidGenerator`: single-threaded, monotonic, high-entropy ULID generation
+  - `LockMonoUlidGenerator`: multi-threaded, monotonic, high-entropy ULID generation
 
 - **Async Support**: Integrates with `tokio` and `smol`
 - **Encoding Support**: Crockford base32 encoding/decoding for compact, sortable

--- a/crates/ferroid-tonic-core/Cargo.toml
+++ b/crates/ferroid-tonic-core/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 publish = true
 
 [dependencies]
-ferroid = { version = "0.5.5", path = "../ferroid", features = ["snowflake", "ulid"] }
+ferroid = { version = "0.5.5", path = "../ferroid", features = ["std", "alloc", "snowflake", "ulid"] }
 prost = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tonic = { workspace = true, features = ["prost", "codegen"] }

--- a/crates/ferroid-tonic-core/Cargo.toml
+++ b/crates/ferroid-tonic-core/Cargo.toml
@@ -7,6 +7,10 @@ authors.workspace = true
 readme = "README.md"
 description = "Shared types for the core gRPC protocol and shared types"
 repository = "https://github.com/s0l0ist/ferroid/blob/main/crates/ferroid-tonic-core"
+categories = [
+  "development-tools",   # Core support crate for a larger system
+  "network-programming", # Shared logic for a gRPC-based service
+]
 documentation.workspace = true
 keywords.workspace = true
 publish = true

--- a/crates/ferroid-tonic-core/Cargo.toml
+++ b/crates/ferroid-tonic-core/Cargo.toml
@@ -16,7 +16,7 @@ keywords.workspace = true
 publish = true
 
 [dependencies]
-ferroid = { version = "0.5.5", path = "../ferroid", features = ["std", "alloc", "snowflake", "ulid"] }
+ferroid = { version = "0.6.0", path = "../ferroid", features = ["std", "alloc", "snowflake"] }
 prost = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tonic = { workspace = true, features = ["prost", "codegen"] }

--- a/crates/ferroid-tonic-core/src/common/error.rs
+++ b/crates/ferroid-tonic-core/src/common/error.rs
@@ -46,12 +46,12 @@ impl From<Error> for Status {
     fn from(err: Error) -> Self {
         match err {
             Error::ChannelError { context } => {
-                Status::internal(format!("Channel error: {context}"))
+                Self::internal(format!("Channel error: {context}"))
             }
-            Error::IdGeneration(e) => Status::internal(format!("ID generation error: {e:?}")),
-            Error::RequestCancelled => Status::cancelled("Request was cancelled"),
-            Error::InvalidRequest { reason } => Status::invalid_argument(reason),
-            Error::ServiceShutdown => Status::unavailable("Service is shutting down"),
+            Error::IdGeneration(e) => Self::internal(format!("ID generation error: {e:?}")),
+            Error::RequestCancelled => Self::cancelled("Request was cancelled"),
+            Error::InvalidRequest { reason } => Self::invalid_argument(reason),
+            Error::ServiceShutdown => Self::unavailable("Service is shutting down"),
         }
     }
 }

--- a/crates/ferroid-tonic-core/src/common/error.rs
+++ b/crates/ferroid-tonic-core/src/common/error.rs
@@ -27,7 +27,7 @@ pub enum Error {
 
     /// Underlying Snowflake ID generation failed.
     #[error("ID error: {0:?}")]
-    IdGeneration(#[from] ferroid::Error),
+    IdGeneration(#[from] ferroid::Error<core::convert::Infallible>),
 
     /// The client aborted the request.
     #[error("Request cancelled by client")]

--- a/crates/ferroid-tonic-core/src/common/error.rs
+++ b/crates/ferroid-tonic-core/src/common/error.rs
@@ -25,9 +25,10 @@ pub enum Error {
     #[error("Channel error: {context}")]
     ChannelError { context: String },
 
-    /// Underlying Snowflake ID generation failed.
+    /// Underlying Snowflake ID generation failed. This is currently infallible,
+    /// but kept as a placeholder if the generator type yields an error.
     #[error("ID error: {0:?}")]
-    IdGeneration(#[from] ferroid::Error<core::convert::Infallible>),
+    IdGeneration(#[from] core::convert::Infallible),
 
     /// The client aborted the request.
     #[error("Request cancelled by client")]
@@ -45,9 +46,7 @@ pub enum Error {
 impl From<Error> for Status {
     fn from(err: Error) -> Self {
         match err {
-            Error::ChannelError { context } => {
-                Self::internal(format!("Channel error: {context}"))
-            }
+            Error::ChannelError { context } => Self::internal(format!("Channel error: {context}")),
             Error::IdGeneration(e) => Self::internal(format!("ID generation error: {e:?}")),
             Error::RequestCancelled => Self::cancelled("Request was cancelled"),
             Error::InvalidRequest { reason } => Self::invalid_argument(reason),

--- a/crates/ferroid-tonic-core/src/common/types.rs
+++ b/crates/ferroid-tonic-core/src/common/types.rs
@@ -47,9 +47,9 @@ use ferroid::{BasicSnowflakeGenerator, CUSTOM_EPOCH, Id, MonotonicClock, Snowfla
 /// The canonical Snowflake ID type used across the system.
 ///
 /// Defaults to [`SnowflakeTwitterId`], but can be replaced in custom builds
-/// with any type implementing [`Snowflake`].
+/// with any type implementing [`SnowflakeId`].
 ///
-/// [`Snowflake`]: crate::ferroid::Snowflake
+/// [`SnowflakeId`]: crate::ferroid::SnowflakeId
 pub type SnowflakeId = SnowflakeTwitterId;
 
 /// The primitive integer type that backs a [`SnowflakeId`] (typically `u64`).

--- a/crates/ferroid-tonic-server/Cargo.toml
+++ b/crates/ferroid-tonic-server/Cargo.toml
@@ -7,6 +7,12 @@ authors.workspace = true
 readme = "README.md"
 description = "A high-performance gRPC server for streaming ID generation"
 repository = "https://github.com/s0l0ist/ferroid/blob/main/crates/ferroid-tonic-server"
+categories = [
+  "network-programming",     # gRPC server for ID generation
+  "asynchronous",            # Uses async runtimes like Tokio
+  "development-tools",       # Infrastructure tooling for distributed systems
+  "concurrency",             # Threaded workers / mpsc / stream batching
+]
 documentation.workspace = true
 keywords.workspace = true
 publish = true

--- a/crates/ferroid-tonic-server/Cargo.toml
+++ b/crates/ferroid-tonic-server/Cargo.toml
@@ -26,7 +26,7 @@ anyhow = { workspace = true, features = ["std"] }
 bytes = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "color", "error-context", "help", "std", "suggestions", "usage"] }
 dotenvy = { workspace = true }
-ferroid-tonic-core = { version = "0.5.5", path = "../ferroid-tonic-core" }
+ferroid-tonic-core = { version = "0.6.0", path = "../ferroid-tonic-core" }
 futures = { workspace = true }
 mimalloc = { workspace = true }
 opentelemetry = { workspace = true, optional = true }

--- a/crates/ferroid-tonic-server/benches/bench.rs
+++ b/crates/ferroid-tonic-server/benches/bench.rs
@@ -30,10 +30,10 @@ enum Compression {
 impl fmt::Display for Compression {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Compression::None => write!(f, "none"),
-            Compression::Deflate => write!(f, "deflate"),
-            Compression::Gzip => write!(f, "gzip"),
-            Compression::Zstd => write!(f, "zstd"),
+            Self::None => write!(f, "none"),
+            Self::Deflate => write!(f, "deflate"),
+            Self::Gzip => write!(f, "gzip"),
+            Self::Zstd => write!(f, "zstd"),
         }
     }
 }
@@ -153,7 +153,7 @@ async fn run_grpc_id_bench(channel: &Channel, params: &GrpcBenchParams) {
         tasks.push(tokio::spawn(async move {
             let mut client = IdGeneratorClient::new(channel);
             if let Some(encoding) = compression.into() {
-                client = client.accept_compressed(encoding).send_compressed(encoding)
+                client = client.accept_compressed(encoding).send_compressed(encoding);
             }
 
             let mut stream = client

--- a/crates/ferroid-tonic-server/benches/bench.rs
+++ b/crates/ferroid-tonic-server/benches/bench.rs
@@ -22,8 +22,6 @@ use tonic::{
 #[derive(Clone, Copy, Debug)]
 enum Compression {
     None,
-    Deflate,
-    Gzip,
     Zstd,
 }
 
@@ -31,8 +29,6 @@ impl fmt::Display for Compression {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::None => write!(f, "none"),
-            Self::Deflate => write!(f, "deflate"),
-            Self::Gzip => write!(f, "gzip"),
             Self::Zstd => write!(f, "zstd"),
         }
     }
@@ -42,8 +38,6 @@ impl From<Compression> for Option<CompressionEncoding> {
     fn from(value: Compression) -> Self {
         match value {
             Compression::None => None,
-            Compression::Deflate => Some(CompressionEncoding::Deflate),
-            Compression::Gzip => Some(CompressionEncoding::Gzip),
             Compression::Zstd => Some(CompressionEncoding::Zstd),
         }
     }
@@ -79,12 +73,7 @@ fn grpc_bench(c: &mut Criterion) {
 
     let ids_per_request_cases = [10_000, 100_000, 1_000_000];
     let concurrency_cases = [1, 2, 4, 8, 16, 32];
-    let compression_cases = [
-        Compression::None,
-        Compression::Zstd,
-        Compression::Gzip,
-        Compression::Deflate,
-    ];
+    let compression_cases = [Compression::None, Compression::Zstd];
 
     // Generate cartesian product of all param combinations
     let mut cases = Vec::new();

--- a/crates/ferroid-tonic-server/src/server/config.rs
+++ b/crates/ferroid-tonic-server/src/server/config.rs
@@ -57,9 +57,9 @@ pub struct CliArgs {
     /// balancing performance (more workers per node) with availability (more
     /// nodes, fewer workers).
     ///
-    /// The total number of distinct machine IDs (shard_offset + num_workers)
-    /// across all nodes must not exceed the machine ID bit width defined by
-    /// your Snowflake format.
+    /// The total number of distinct machine IDs (`shard_offset` +
+    /// `num_workers`) across all nodes must not exceed the machine ID bit width
+    /// defined by your Snowflake format.
     ///
     /// Environment variable: `NUM_WORKERS`
     ///
@@ -115,8 +115,9 @@ pub struct CliArgs {
     /// during shutdown.
     ///
     /// This grace period allows in-flight requests to finish cleanly before
-    /// forcibly shutting down workers. If the timeout is reached and streams are
-    /// still active, the server proceeds with termination and logs a warning.
+    /// forcibly shutting down workers. If the timeout is reached and streams
+    /// are still active, the server proceeds with termination and logs a
+    /// warning.
     ///
     /// Environment variable: `SHUTDOWN_TIMEOUT`
     ///

--- a/crates/ferroid-tonic-server/src/server/pool/manager.rs
+++ b/crates/ferroid-tonic-server/src/server/pool/manager.rs
@@ -36,7 +36,7 @@ pub struct WorkerPool {
 impl WorkerPool {
     /// Constructs a new [`WorkerPool`] from initialized worker channels and a
     /// shared cancellation token.
-    pub fn new(
+    pub const fn new(
         workers: Vec<mpsc::Sender<WorkRequest>>,
         shutdown_token: CancellationToken,
         shutdown_timeout: usize,
@@ -106,7 +106,7 @@ impl WorkerPool {
         .await;
 
         match drain_result {
-            Ok(_) => {
+            Ok(()) => {
                 #[cfg(feature = "tracing")]
                 tracing::debug!("All in-flight streams drained successfully");
             }

--- a/crates/ferroid-tonic-server/src/server/service/handler.rs
+++ b/crates/ferroid-tonic-server/src/server/service/handler.rs
@@ -194,7 +194,7 @@ impl IdGenerator for IdService {
         }
 
         increment_requests_metric();
-        record_ids_per_request_metric(total_ids as f64);
+        record_ids_per_request_metric(req.get_ref().count);
         increment_streams_inflight(); // global
         increment_streams_inflight_metric();
 

--- a/crates/ferroid-tonic-server/src/server/streaming/coordinator.rs
+++ b/crates/ferroid-tonic-server/src/server/streaming/coordinator.rs
@@ -74,7 +74,7 @@ pub async fn feed_chunks(
                 // the client.
                 if let Err(_e) = resp_tx.send(Err(e.clone().into())).await {
                     #[cfg(feature = "tracing")]
-                    tracing::warn!("Failed to forward err: {}", _e)
+                    tracing::warn!("Failed to forward err: {}", _e);
                 }
                 return Err(e);
             }

--- a/crates/ferroid-tonic-server/src/server/telemetry.rs
+++ b/crates/ferroid-tonic-server/src/server/telemetry.rs
@@ -321,7 +321,7 @@ static STREAM_DURATION_MS_METRIC: OnceLock<Histogram<f64>> = OnceLock::new();
 #[cfg(feature = "metrics")]
 static IDS_GENERATED_METRIC: OnceLock<Counter<u64>> = OnceLock::new();
 #[cfg(feature = "metrics")]
-static IDS_PER_REQUEST_METRIC: OnceLock<Histogram<f64>> = OnceLock::new();
+static IDS_PER_REQUEST_METRIC: OnceLock<Histogram<u64>> = OnceLock::new();
 
 #[cfg(feature = "metrics")]
 fn init_metric_handles(meter: Meter) {
@@ -363,7 +363,7 @@ fn init_metric_handles(meter: Meter) {
 
     let _ = IDS_PER_REQUEST_METRIC.set(
         meter
-            .f64_histogram("ids_per_request")
+            .u64_histogram("ids_per_request")
             .with_description("IDs requested per stream")
             .build(),
     );
@@ -431,11 +431,11 @@ pub fn increment_ids_generated_metric(count: u64) {
 pub fn increment_ids_generated_metric(_count: u64) {}
 
 #[cfg(feature = "metrics")]
-pub fn record_ids_per_request_metric(count: f64) {
+pub fn record_ids_per_request_metric(count: u64) {
     if let Some(histogram) = IDS_PER_REQUEST_METRIC.get() {
         histogram.record(count, &[]);
     }
 }
 
 #[cfg(not(feature = "metrics"))]
-pub fn record_ids_per_request_metric(_count: f64) {}
+pub fn record_ids_per_request_metric(_count: u64) {}

--- a/crates/ferroid/Cargo.toml
+++ b/crates/ferroid/Cargo.toml
@@ -28,7 +28,7 @@ crate-type = ["rlib"]
 base32 = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 pin-project-lite = { workspace = true, optional = true }
-rand = { workspace = true, optional = true }
+rand = { workspace = true, optional = true, features = ["thread_rng"] }
 serde = { workspace = true, optional = true, features = ["derive"] }
 smol = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true, features = ["time", "rt-multi-thread"] }
@@ -47,7 +47,7 @@ harness = false
 
 [features]
 default = []
-std = ["rand?/thread_rng"]
+std = ["dep:rand"]
 alloc = []
 thread_local = ["std", "alloc"]
 snowflake = []

--- a/crates/ferroid/Cargo.toml
+++ b/crates/ferroid/Cargo.toml
@@ -14,7 +14,7 @@ keywords.workspace = true
 all-features = true
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["rlib"]
 
 [dependencies]
 base32 = { workspace = true, optional = true }
@@ -29,7 +29,7 @@ tracing = { workspace = true, optional = true, features = ["attributes"] }
 [dev-dependencies]
 async-lock = { workspace = true }
 criterion = { workspace = true, features = ["async_tokio", "async_smol"] }
-futures = { workspace = true,  features = ["alloc"] }
+futures = { workspace = true, features = ["alloc"] }
 num_cpus = { workspace = true }
 tokio = { workspace = true, features = ["macros", "sync"] }
 
@@ -39,12 +39,15 @@ harness = false
 
 [features]
 default = []
+std = []
+alloc = []
+thread_local = ["std", "alloc", "dep:rand"]
 snowflake = []
-ulid = ["dep:rand"]
+ulid = []
 
 tracing = ["dep:tracing"]
 serde = ["dep:serde"]
 base32 = ["dep:base32"]
 futures = ["dep:futures", "dep:pin-project-lite"]
-async-tokio = ["futures", "dep:tokio"]
-async-smol = ["futures", "dep:smol"]
+async-tokio = ["std", "alloc", "futures", "dep:tokio"]
+async-smol = ["std", "futures", "dep:smol"]

--- a/crates/ferroid/Cargo.toml
+++ b/crates/ferroid/Cargo.toml
@@ -28,7 +28,7 @@ crate-type = ["rlib"]
 base32 = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 pin-project-lite = { workspace = true, optional = true }
-rand = { workspace = true, optional = true, features = ["thread_rng"] }
+rand = { workspace = true, optional = true }
 serde = { workspace = true, optional = true, features = ["derive"] }
 smol = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true, features = ["time", "rt-multi-thread"] }
@@ -47,9 +47,9 @@ harness = false
 
 [features]
 default = []
-std = []
+std = ["rand?/thread_rng"]
 alloc = []
-thread_local = ["std", "alloc", "dep:rand"]
+thread_local = ["std", "alloc"]
 snowflake = []
 ulid = []
 
@@ -58,4 +58,4 @@ serde = ["dep:serde"]
 base32 = ["dep:base32"]
 futures = ["dep:futures", "dep:pin-project-lite"]
 async-tokio = ["std", "alloc", "futures", "dep:tokio"]
-async-smol = ["std", "futures", "dep:smol"]
+async-smol = ["std", "alloc", "futures", "dep:smol"]

--- a/crates/ferroid/Cargo.toml
+++ b/crates/ferroid/Cargo.toml
@@ -9,7 +9,7 @@ description = "Flexible ID generators for producing unique, monotonic, and lexic
 repository = "https://github.com/s0l0ist/ferroid/blob/main/crates/ferroid"
 categories = [
   "algorithms",         # Implements time-sortable ID generation algorithms
-  "data-structures",    # Exposes structured types like ULID, Snowflake, etc.
+  "data-structures",    # Exposes structured types like ULID, SnowflakeId, etc.
   "encoding",           # Optional Base32 support (Crockford-style)
   "asynchronous",       # If using async stream generation features
   "no-std",             # Supports no_std-compatible environments

--- a/crates/ferroid/Cargo.toml
+++ b/crates/ferroid/Cargo.toml
@@ -7,6 +7,14 @@ authors.workspace = true
 readme = "README.md"
 description = "Flexible ID generators for producing unique, monotonic, and lexicographically sortable IDs."
 repository = "https://github.com/s0l0ist/ferroid/blob/main/crates/ferroid"
+categories = [
+  "algorithms",         # Implements time-sortable ID generation algorithms
+  "data-structures",    # Exposes structured types like ULID, Snowflake, etc.
+  "encoding",           # Optional Base32 support (Crockford-style)
+  "asynchronous",       # If using async stream generation features
+  "no-std",             # Supports no_std-compatible environments
+  "development-tools"   # Broad utility for developers building systems
+]
 documentation.workspace = true
 keywords.workspace = true
 

--- a/crates/ferroid/README.md
+++ b/crates/ferroid/README.md
@@ -310,19 +310,23 @@ Where:
 - $r$ = number of random bits per ID
 - $P_\text{collision}$ = probability of at least one collision
 
-> Note:
-> The formula above uses the approximate (birthday bound) model, which assumes that:
+> Note: The formula above uses the approximate (birthday bound) model, which
+> assumes that:
 >
 > - $k \ll 2^r$ and $g \ll 2^r$
-> - Each generator's range of $k$ IDs starts at a uniformly random position within the $r$-bit space
+> - Each generator's range of $k$ IDs starts at a uniformly random position
+>   within the $r$-bit space
 
 #### Estimating Time Until a Collision Occurs
 
-While collisions only happen within a single millisecond, we often want to know how long it takes before **any** collision happens, given continuous generation over time.
+While collisions only happen within a single millisecond, we often want to know
+how long it takes before **any** collision happens, given continuous generation
+over time.
 
 The expected time in milliseconds to reach a 50% chance of collision is:
 
-$T_{\text{50\%}} \approx \frac{\ln 2}{P_\text{collision}} = \frac{0.6931 \cdot 2 \cdot 2^r}{g(g - 1)(2k - 1)}$
+$T_{\text{50\%}} \approx \frac{\ln 2}{P_\text{collision}} = \frac{0.6931 \cdot 2
+\cdot 2^r}{g(g - 1)(2k - 1)}$
 
 This is derived from the cumulative probability formula:
 
@@ -334,11 +338,13 @@ $(1 - P_\text{collision})^T = 0.5$
 
 $\Rightarrow T \approx \frac{\ln(0.5)}{\ln(1 - P_\text{collision})}$
 
-Using the approximation $\ln(1 - x) \approx -x$ for small $x$, this simplifies to:
+Using the approximation $\ln(1 - x) \approx -x$ for small $x$, this simplifies
+to:
 
 $\Rightarrow T \approx \frac{\ln 2}{P_\text{collision}}$
 
-The $\ln 2$ term arises because $\ln(0.5) = -\ln 2$. After $T_\text{50\%}$ milliseconds, there's a 50% chance that at least one collision has occurred.
+The $\ln 2$ term arises because $\ln(0.5) = -\ln 2$. After $T_\text{50\%}$
+milliseconds, there's a 50% chance that at least one collision has occurred.
 
 | Generators ($g$) | IDs per generator per ms ($k$) | $P_\text{collision}$                                                                                    | Estimated Time to 50% Collision ($T_{\text{50\%}}$)         |
 | ---------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
@@ -437,29 +443,29 @@ efficiency).
 
 #### Synchronous Generators
 
-| Generator                | Time per ID | Throughput    |
-| ------------------------ | ----------- | ------------- |
-| BasicSnowflakeGenerator  | **~2.8 ns** | ~353M IDs/sec |
-| LockSnowflakeGenerator   | **~8.9 ns** | ~111M IDs/sec |
-| AtomicSnowflakeGenerator | **~3.1 ns** | ~320M IDs/sec |
-| BasicUlidGenerator       | **~3.4 ns** | ~288M IDs/sec |
-| LockUlidGenerator        | **~9.2 ns** | ~109M IDs/sec |
+| Generator                  | Time per ID | Throughput    |
+| -------------------------- | ----------- | ------------- |
+| `BasicSnowflakeGenerator`  | **~2.8 ns** | ~353M IDs/sec |
+| `LockSnowflakeGenerator`   | **~8.9 ns** | ~111M IDs/sec |
+| `AtomicSnowflakeGenerator` | **~3.1 ns** | ~320M IDs/sec |
+| `BasicUlidGenerator`       | **~3.4 ns** | ~288M IDs/sec |
+| `LockUlidGenerator`        | **~9.2 ns** | ~109M IDs/sec |
 
 #### Async (Tokio Runtime) - Peak throughput
 
-| Generator                | Generators | Time per ID  | Throughput     |
-| ------------------------ | ---------- | ------------ | -------------- |
-| LockSnowflakeGenerator   | 1024       | **~1.46 ns** | ~687M IDs/sec  |
-| AtomicSnowflakeGenerator | 1024       | **~0.86 ns** | ~1.17B IDs/sec |
-| LockUlidGenerator        | 1024       | **~1.57 ns** | ~635M IDs/sec  |
+| Generator                  | Generators | Time per ID  | Throughput     |
+| -------------------------- | ---------- | ------------ | -------------- |
+| `LockSnowflakeGenerator`   | 1024       | **~1.46 ns** | ~687M IDs/sec  |
+| `AtomicSnowflakeGenerator` | 1024       | **~0.86 ns** | ~1.17B IDs/sec |
+| `LockUlidGenerator`        | 1024       | **~1.57 ns** | ~635M IDs/sec  |
 
 #### Async (Smol Runtime) - Peak throughput
 
-| Generator                | Generators | Time per ID  | Throughput     |
-| ------------------------ | ---------- | ------------ | -------------- |
-| LockSnowflakeGenerator   | 1024       | **~1.40 ns** | ~710M IDs/sec  |
-| AtomicSnowflakeGenerator | 1024       | **~0.62 ns** | ~1.61B IDs/sec |
-| LockUlidGenerator        | 1024       | **~1.32 ns** | ~756M IDs/sec  |
+| Generator                  | Generators | Time per ID  | Throughput     |
+| -------------------------- | ---------- | ------------ | -------------- |
+| `LockSnowflakeGenerator`   | 1024       | **~1.40 ns** | ~710M IDs/sec  |
+| `AtomicSnowflakeGenerator` | 1024       | **~0.62 ns** | ~1.61B IDs/sec |
+| `LockUlidGenerator`        | 1024       | **~1.32 ns** | ~756M IDs/sec  |
 
 To run all benchmarks:
 

--- a/crates/ferroid/README.md
+++ b/crates/ferroid/README.md
@@ -50,9 +50,9 @@ and parsing **Snowflake** and **ULID** identifiers.
 
 | Ulid Generator           | Monotonic | Thread-Safe | Lock-Free | Throughput | Use Case                                |
 | ------------------------ | --------- | ----------- | --------- | ---------- | --------------------------------------- |
-| `BasicUlidGenerator`     | ❌        | ✅          | ❌        | High       | Multi-threaded, always random           |
+| `BasicUlidGenerator`     | ❌        | ✅          | ❌        | Medium     | Multi-threaded, always random           |
 | `BasicMonoUlidGenerator` | ✅        | ❌          | ❌        | Highest    | Single-threaded or generator per thread |
-| `LockMonoUlidGenerator`  | ✅        | ✅          | ❌        | Medium     | Fair multithreaded access               |
+| `LockMonoUlidGenerator`  | ✅        | ✅          | ❌        | High       | Fair multithreaded access               |
 
 ## 🚀 Usage
 
@@ -60,22 +60,19 @@ and parsing **Snowflake** and **ULID** identifiers.
 
 #### Thread Locals
 
-The simplest way to generate a ULID is via `Ulid`, which provides a
-thread-local generator:
+The simplest way to generate a ULID is via `Ulid`, which provides a thread-local
+generator that can produce both non-monotonic and monotonic ULIDs:
 
 ```rust
 #[cfg(all(feature = "ulid", feature = "thread_local"))]
 {
     use ferroid::{ULID, Ulid};
 
+    // A ULID (slower, always random within the same millisecond)
     let id: ULID = Ulid::new_ulid();
-}
 
-#[cfg(all(feature = "ulid", feature = "thread_local"))]
-{
-    use ferroid::{ULID, Ulid};
-
-    let id: ULID = Ulid::new_ulid();
+    // A monotonic ULID (faster, increments within the same millisecond)
+    let id: ULID = Ulid::new_mono_ulid();
 }
 ```
 
@@ -476,6 +473,7 @@ efficiency).
 | `LockSnowflakeGenerator`   | **~8.9 ns** | ~111M IDs/sec |
 | `AtomicSnowflakeGenerator` | **~3.1 ns** | ~320M IDs/sec |
 | `BasicUlidGenerator`       | **~3.4 ns** | ~288M IDs/sec |
+| `BasicMonoUlidGenerator`   | **~3.4 ns** | ~44M IDs/sec  |
 | `LockMonoUlidGenerator`    | **~9.2 ns** | ~109M IDs/sec |
 
 #### Async (Tokio Runtime) - Peak throughput

--- a/crates/ferroid/README.md
+++ b/crates/ferroid/README.md
@@ -76,7 +76,7 @@ generator that can produce both non-monotonic and monotonic ULIDs:
 }
 ```
 
-Thread-local generators are not currently available for `Snowflake`-style IDs
+Thread-local generators are not currently available for `SnowflakeId`-style IDs
 because they rely on a valid `machine_id` to avoid collisions. Mapping unique
 `machine_id`s across threads requires coordination beyond what `thread_local!`
 alone can guarantee.
@@ -400,7 +400,7 @@ Use `.encode()` or `.encode_to_buf()` for sortable string representations:
 
 #[cfg(all(feature = "base32", feature = "ulid"))]
 {
-    use ferroid::{Base32UlidExt, Ulid, ULID};
+    use ferroid::{Base32UlidExt, UlidId, ULID};
 
     let id = ULID::from(123456, 42);
     assert_eq!(format!("default: {id}"), "default: 149249145986343659392525664298");

--- a/crates/ferroid/README.md
+++ b/crates/ferroid/README.md
@@ -63,9 +63,9 @@ Calling `next_id()` may yield `Pending` if the current sequence is exhausted. In
 that case, you can spin, yield, or sleep depending on your environment:
 
 ```rust
-#[cfg(feature = "snowflake")]
+#[cfg(all(feature = "std", feature = "alloc", feature = "snowflake"))]
 {
-    use ferroid::{MonotonicClock, TWITTER_EPOCH, BasicSnowflakeGenerator, SnowflakeTwitterId, IdGenStatus};
+    use ferroid::{MonotonicClock, IdGenStatus, TWITTER_EPOCH, BasicSnowflakeGenerator, SnowflakeTwitterId};
 
     let clock = MonotonicClock::with_epoch(TWITTER_EPOCH);
     let generator = BasicSnowflakeGenerator::new(0, clock);
@@ -85,7 +85,7 @@ that case, you can spin, yield, or sleep depending on your environment:
     };
 }
 
-#[cfg(feature = "ulid")]
+#[cfg(all(feature = "std", feature = "alloc", feature = "ulid"))]
 {
     use ferroid::{MonotonicClock, IdGenStatus, UNIX_EPOCH, ThreadRandom, BasicUlidGenerator, ULID};
 

--- a/crates/ferroid/benches/bench.rs
+++ b/crates/ferroid/benches/bench.rs
@@ -4,7 +4,7 @@ use criterion::async_executor::SmolExecutor;
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use ferroid::{
     AtomicSnowflakeGenerator, Base32SnowExt, Base32UlidExt, BasicSnowflakeGenerator,
-    BasicUlidGenerator, BeBytes, Error, Id, IdGenStatus, LockSnowflakeGenerator, LockUlidGenerator,
+    BasicUlidGenerator, BeBytes, Id, IdGenStatus, LockSnowflakeGenerator, LockUlidGenerator,
     MonotonicClock, RandSource, SmolSleep, Snowflake, SnowflakeGenerator,
     SnowflakeGeneratorAsyncExt, SnowflakeMastodonId, SnowflakeTwitterId, ThreadRandom, TimeSource,
     ToU64, TokioSleep, ULID, Ulid, UlidGenerator, UlidGeneratorAsyncExt, UlidMono,
@@ -176,6 +176,7 @@ fn bench_generator_async_tokio<ID, G, T>(
 ) where
     ID: Snowflake + Send + Sync + 'static,
     G: SnowflakeGenerator<ID, T> + Send + Sync + 'static,
+    G::Err: Send + Sync + 'static,
     T: TimeSource<ID::Ty> + Clone + Send + Sync + 'static,
 {
     let mut group = c.benchmark_group(group_name);
@@ -203,7 +204,7 @@ fn bench_generator_async_tokio<ID, G, T>(
                                 let id = generator.try_next_id_async::<TokioSleep>().await?;
                                 black_box(id);
                             }
-                            Ok::<(), Error<core::convert::Infallible>>(())
+                            Ok::<(), G::Err>(())
                         })
                     });
                     try_join_all(tasks).await.unwrap();
@@ -226,6 +227,7 @@ pub fn bench_generator_async_smol<ID, G, T>(
 ) where
     ID: Snowflake + Send + Sync + 'static,
     G: SnowflakeGenerator<ID, T> + Send + Sync + 'static,
+    G::Err: Send + Sync + 'static,
     T: TimeSource<ID::Ty> + Clone + Send + Sync + 'static,
 {
     // Use all CPUs
@@ -254,7 +256,7 @@ pub fn bench_generator_async_smol<ID, G, T>(
                                 let id = generator.try_next_id_async::<SmolSleep>().await?;
                                 black_box(id);
                             }
-                            Ok::<(), Error<core::convert::Infallible>>(())
+                            Ok::<(), G::Err>(())
                         })
                     });
                     try_join_all(tasks).await.unwrap();
@@ -377,6 +379,7 @@ fn bench_ulid_generator_async_tokio<ID, G, T, R>(
 ) where
     ID: Ulid + Send + Sync + 'static,
     G: UlidGenerator<ID, T, R> + Send + Sync + 'static,
+    G::Err: Send + Sync + 'static,
     T: TimeSource<ID::Ty> + Clone + Send + Sync + 'static,
     R: RandSource<ID::Ty> + Clone + Send + Sync + 'static,
 {
@@ -407,7 +410,7 @@ fn bench_ulid_generator_async_tokio<ID, G, T, R>(
                                 let id = generator.try_next_id_async::<TokioSleep>().await?;
                                 black_box(id);
                             }
-                            Ok::<(), Error<core::convert::Infallible>>(())
+                            Ok::<(), G::Err>(())
                         })
                     });
                     try_join_all(tasks).await.unwrap();
@@ -431,6 +434,7 @@ fn bench_ulid_generator_async_smol<ID, G, T, R>(
 ) where
     ID: Ulid + Send + Sync + 'static,
     G: UlidGenerator<ID, T, R> + Send + Sync + 'static,
+    G::Err: Send + Sync + 'static,
     T: TimeSource<ID::Ty> + Clone + Send + Sync + 'static,
     R: RandSource<ID::Ty> + Clone + Send + Sync + 'static,
 {
@@ -462,7 +466,7 @@ fn bench_ulid_generator_async_smol<ID, G, T, R>(
                                 let id = generator.try_next_id_async::<SmolSleep>().await?;
                                 black_box(id);
                             }
-                            Ok::<(), Error<core::convert::Infallible>>(())
+                            Ok::<(), G::Err>(())
                         })
                     });
                     try_join_all(tasks).await.unwrap();

--- a/crates/ferroid/benches/bench.rs
+++ b/crates/ferroid/benches/bench.rs
@@ -203,7 +203,7 @@ fn bench_generator_async_tokio<ID, G, T>(
                                 let id = generator.try_next_id_async::<TokioSleep>().await?;
                                 black_box(id);
                             }
-                            Ok::<(), Error>(())
+                            Ok::<(), Error<core::convert::Infallible>>(())
                         })
                     });
                     try_join_all(tasks).await.unwrap();
@@ -254,7 +254,7 @@ pub fn bench_generator_async_smol<ID, G, T>(
                                 let id = generator.try_next_id_async::<SmolSleep>().await?;
                                 black_box(id);
                             }
-                            Ok::<(), Error>(())
+                            Ok::<(), Error<core::convert::Infallible>>(())
                         })
                     });
                     try_join_all(tasks).await.unwrap();
@@ -407,7 +407,7 @@ fn bench_ulid_generator_async_tokio<ID, G, T, R>(
                                 let id = generator.try_next_id_async::<TokioSleep>().await?;
                                 black_box(id);
                             }
-                            Ok::<(), Error>(())
+                            Ok::<(), Error<core::convert::Infallible>>(())
                         })
                     });
                     try_join_all(tasks).await.unwrap();
@@ -462,7 +462,7 @@ fn bench_ulid_generator_async_smol<ID, G, T, R>(
                                 let id = generator.try_next_id_async::<SmolSleep>().await?;
                                 black_box(id);
                             }
-                            Ok::<(), Error>(())
+                            Ok::<(), Error<core::convert::Infallible>>(())
                         })
                     });
                     try_join_all(tasks).await.unwrap();

--- a/crates/ferroid/benches/bench.rs
+++ b/crates/ferroid/benches/bench.rs
@@ -650,9 +650,9 @@ where
 fn bench_thread_local_ulid(c: &mut Criterion, group_name: &str) {
     let mut group = c.benchmark_group(group_name);
     group.throughput(Throughput::Elements(1));
-    group.bench_function("new", |b| {
+    group.bench_function("new_ulid", |b| {
         b.iter(|| {
-            black_box(UlidMono::new());
+            black_box(UlidMono::new_ulid());
         });
     });
     group.bench_function("from_timestamp", |b| {
@@ -686,7 +686,7 @@ pub fn bench_thread_local_ulid_threaded(c: &mut Criterion, group_name: &str) {
                         for _ in 0..thread_count {
                             s.spawn(|| {
                                 for _ in 0..TOTAL_IDS {
-                                    black_box(UlidMono::new());
+                                    black_box(UlidMono::new_ulid());
                                 }
                             });
                         }

--- a/crates/ferroid/benches/bench.rs
+++ b/crates/ferroid/benches/bench.rs
@@ -219,6 +219,9 @@ fn bench_generator_async_tokio<ID, G, T>(
 
 /// Benchmarks many async generators in parallel, each running in a separate
 /// `smol` task.
+///
+/// # Panics
+/// - If a task fails
 pub fn bench_generator_async_smol<ID, G, T>(
     c: &mut Criterion,
     group_name: &str,

--- a/crates/ferroid/benches/bench.rs
+++ b/crates/ferroid/benches/bench.rs
@@ -520,7 +520,7 @@ where
     group.bench_function("encode/buffer/format", |b| {
         b.iter(|| {
             let b = id.encode_to_buf(black_box(&mut buf));
-            black_box(format!("{}", b));
+            black_box(format!("{b}"));
         });
     });
 
@@ -587,7 +587,7 @@ where
     group.bench_function("encode/buffer/format", |b| {
         b.iter(|| {
             let b = id.encode_to_buf(black_box(&mut buf));
-            black_box(format!("{}", b));
+            black_box(format!("{b}"));
         });
     });
 

--- a/crates/ferroid/benches/bench.rs
+++ b/crates/ferroid/benches/bench.rs
@@ -25,7 +25,7 @@ impl TimeSource<u64> for FixedMockTime {
 
 impl TimeSource<u128> for FixedMockTime {
     fn current_millis(&self) -> u128 {
-        self.millis as u128
+        u128::from(self.millis)
     }
 }
 
@@ -156,7 +156,7 @@ fn bench_generator_threaded<ID, G, T>(
                                 }
                             });
                         }
-                    })
+                    });
                 }
                 start.elapsed()
             });
@@ -356,7 +356,7 @@ fn bench_generator_ulid_threaded<ID, G, T, R>(
                                 }
                             });
                         }
-                    })
+                    });
                 }
                 start.elapsed()
             });
@@ -762,7 +762,7 @@ fn bench_generator_threaded_basic(c: &mut Criterion) {
         "mono/threaded/basic",
         BasicSnowflakeGenerator::new,
         MonotonicClock::default,
-    )
+    );
 }
 /// Multi-threaded benchmark for `LockSnowflakeGenerator` with `MonotonicClock`.
 fn bench_generator_threaded_lock(c: &mut Criterion) {
@@ -771,7 +771,7 @@ fn bench_generator_threaded_lock(c: &mut Criterion) {
         "mono/threaded/lock",
         LockSnowflakeGenerator::new,
         MonotonicClock::default,
-    )
+    );
 }
 /// Multi-threaded benchmark for `AtomicSnowflakeGenerator` with
 /// `MonotonicClock`.
@@ -781,7 +781,7 @@ fn bench_generator_threaded_atomic(c: &mut Criterion) {
         "mono/threaded/atomic",
         AtomicSnowflakeGenerator::new,
         MonotonicClock::default,
-    )
+    );
 }
 
 // --- ASYNC ---
@@ -830,8 +830,7 @@ fn benchmark_mono_smol_atomic(c: &mut Criterion) {
     );
 }
 
-// --- Ulid ---
-// Mocks
+// --- Ulid --- Mocks
 fn benchmark_mock_sequential_ulid_basic(c: &mut Criterion) {
     let rand = ThreadRandom;
     bench_generator_ulid::<ULID, _, _, _>(c, "mock/sequential/ulid/basic", || {

--- a/crates/ferroid/src/base32/be_bytes.rs
+++ b/crates/ferroid/src/base32/be_bytes.rs
@@ -33,7 +33,7 @@ pub trait BeBytes: Sized {
     fn from_be_bytes(bytes: Self::ByteArray) -> Self;
 }
 impl BeBytes for u32 {
-    const SIZE: usize = core::mem::size_of::<u32>();
+    const SIZE: usize = core::mem::size_of::<Self>();
     const BASE32_SIZE: usize = base32_size(Self::SIZE);
 
     type ByteArray = [u8; Self::SIZE];
@@ -48,7 +48,7 @@ impl BeBytes for u32 {
     }
 }
 impl BeBytes for u64 {
-    const SIZE: usize = core::mem::size_of::<u64>();
+    const SIZE: usize = core::mem::size_of::<Self>();
     const BASE32_SIZE: usize = base32_size(Self::SIZE);
 
     type ByteArray = [u8; Self::SIZE];
@@ -63,7 +63,7 @@ impl BeBytes for u64 {
     }
 }
 impl BeBytes for u128 {
-    const SIZE: usize = core::mem::size_of::<u128>();
+    const SIZE: usize = core::mem::size_of::<Self>();
     const BASE32_SIZE: usize = base32_size(Self::SIZE);
 
     type ByteArray = [u8; Self::SIZE];

--- a/crates/ferroid/src/base32/be_bytes.rs
+++ b/crates/ferroid/src/base32/be_bytes.rs
@@ -1,4 +1,4 @@
-use std::hash::Hash;
+use core::hash::Hash;
 
 const fn base32_size(bytes: usize) -> usize {
     (bytes * 8).div_ceil(5)

--- a/crates/ferroid/src/base32/crockford.rs
+++ b/crates/ferroid/src/base32/crockford.rs
@@ -43,7 +43,7 @@ const LOOKUP: [u8; 256] = {
 ///   - Therefore, `ALPHABET[(acc >> bits) & 0x1F]` is guaranteed to be
 ///     in-bounds.
 #[inline(always)]
-pub(crate) fn encode_base32(input: &[u8], buf_slice: &mut [u8]) {
+pub fn encode_base32(input: &[u8], buf_slice: &mut [u8]) {
     let input_bits = input.len() * 8;
     let output_chars = buf_slice.len();
     let total_bits = output_chars * BITS_PER_CHAR;
@@ -53,7 +53,7 @@ pub(crate) fn encode_base32(input: &[u8], buf_slice: &mut [u8]) {
 
     let mut out = 0;
     for &b in input {
-        acc = (acc << 8) | b as u16;
+        acc = (acc << 8) | u16::from(b);
         bits += 8;
         while bits >= BITS_PER_CHAR {
             bits -= BITS_PER_CHAR;
@@ -82,7 +82,7 @@ pub(crate) fn encode_base32(input: &[u8], buf_slice: &mut [u8]) {
 /// - `LOOKUP` is a fixed-size array of 256 elements, so `LOOKUP[b as usize]` is
 ///   always in-bounds.
 #[inline(always)]
-pub(crate) fn decode_base32<T, E>(encoded: &str) -> Result<T, E>
+pub fn decode_base32<T, E>(encoded: &str) -> Result<T, E>
 where
     T: BeBytes
         + Default
@@ -136,7 +136,7 @@ mod tests {
 
     #[test]
     fn test_roundtrip_u32() {
-        for &v in &[0, 1, u32::MAX, u32::MIN, 42, 0xFF00FF00, 0x12345678] {
+        for &v in &[0, 1, u32::MAX, u32::MIN, 42, 0xFF00_FF00, 0x1234_5678] {
             roundtrip_u32(v);
         }
     }
@@ -149,8 +149,8 @@ mod tests {
             u64::MAX,
             u64::MIN,
             42,
-            0xFF00FF00FF00FF00,
-            0x1234567890ABCDEF,
+            0xFF00_FF00_FF00_FF00,
+            0x1234_5678_90AB_CDEF,
         ] {
             roundtrip_u64(v);
         }
@@ -164,8 +164,8 @@ mod tests {
             u128::MAX,
             u128::MIN,
             42,
-            0xFFFF0000FFFF0000FFFF0000FFFF0000,
-            0x0123456789ABCDEF0123456789ABCDEFu128,
+            0xFFFF_0000_FFFF_0000_FFFF_0000_FFFF_0000,
+            0x0123_4567_89AB_CDEF_0123_4567_89AB_CDEF,
         ] {
             roundtrip_u128(v);
         }
@@ -205,7 +205,7 @@ mod tests {
 
     #[test]
     fn test_ulid_ts() {
-        let time: u128 = 1469922850259;
+        let time: u128 = 1_469_922_850_259;
         let time_bytes = time.to_be_bytes();
         let mut out = [0u8; 26];
         encode_base32(&time_bytes, &mut out);

--- a/crates/ferroid/src/base32/crockford.rs
+++ b/crates/ferroid/src/base32/crockford.rs
@@ -84,7 +84,7 @@ pub fn encode_base32(input: &[u8], buf_slice: &mut [u8]) {
 ///   always in-bounds.
 #[inline(always)]
 #[allow(clippy::inline_always)]
-pub fn decode_base32<T, E>(encoded: &str) -> Result<T, E>
+pub fn decode_base32<T, E>(encoded: &str) -> Result<T, Error<E>>
 where
     T: BeBytes
         + Default

--- a/crates/ferroid/src/base32/crockford.rs
+++ b/crates/ferroid/src/base32/crockford.rs
@@ -108,7 +108,6 @@ where
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
-    use std;
 
     fn roundtrip_u32(val: u32) {
         let bytes = val.to_be_bytes();

--- a/crates/ferroid/src/base32/crockford.rs
+++ b/crates/ferroid/src/base32/crockford.rs
@@ -43,6 +43,7 @@ const LOOKUP: [u8; 256] = {
 ///   - Therefore, `ALPHABET[(acc >> bits) & 0x1F]` is guaranteed to be
 ///     in-bounds.
 #[inline(always)]
+#[allow(clippy::inline_always)]
 pub fn encode_base32(input: &[u8], buf_slice: &mut [u8]) {
     let input_bits = input.len() * 8;
     let output_chars = buf_slice.len();
@@ -82,6 +83,7 @@ pub fn encode_base32(input: &[u8], buf_slice: &mut [u8]) {
 /// - `LOOKUP` is a fixed-size array of 256 elements, so `LOOKUP[b as usize]` is
 ///   always in-bounds.
 #[inline(always)]
+#[allow(clippy::inline_always)]
 pub fn decode_base32<T, E>(encoded: &str) -> Result<T, E>
 where
     T: BeBytes

--- a/crates/ferroid/src/base32/crockford.rs
+++ b/crates/ferroid/src/base32/crockford.rs
@@ -7,13 +7,13 @@ const BITS_PER_CHAR: usize = 5;
 /// Lookup table for Crockford base32 decoding
 const LOOKUP: [u8; 256] = {
     let mut lut = [NO_VALUE; 256];
-    let mut i = 0;
+    let mut i = 0_u8;
     // Main alphabet, allow lower-case
     while i < 32 {
-        let c = ALPHABET[i];
-        lut[c as usize] = i as u8;
+        let c = ALPHABET[i as usize];
+        lut[c as usize] = i;
         if c.is_ascii_uppercase() {
-            lut[(c + 32) as usize] = i as u8; // lowercase letter
+            lut[(c + 32) as usize] = i; // lowercase letter
         }
         i += 1;
     }

--- a/crates/ferroid/src/base32/crockford.rs
+++ b/crates/ferroid/src/base32/crockford.rs
@@ -105,9 +105,10 @@ where
     Ok(acc)
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
+    use std;
 
     fn roundtrip_u32(val: u32) {
         let bytes = val.to_be_bytes();

--- a/crates/ferroid/src/base32/error.rs
+++ b/crates/ferroid/src/base32/error.rs
@@ -2,12 +2,12 @@ use crate::Error;
 use core::fmt;
 
 #[derive(Clone, Debug)]
-pub enum Base32Error {
+pub enum Base32Error<E> {
     DecodeInvalidLen(usize),
     DecodeInvalidAscii(u8),
-    DecodeOverflow(Vec<u8>),
+    DecodeOverflow(E),
 }
-impl fmt::Display for Base32Error {
+impl<E: core::fmt::Debug> fmt::Display for Base32Error<E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Base32Error::DecodeInvalidAscii(b) => write!(f, "invalid ascii byte: {b}"),
@@ -16,9 +16,9 @@ impl fmt::Display for Base32Error {
         }
     }
 }
-impl core::error::Error for Base32Error {}
-impl From<Base32Error> for Error {
-    fn from(err: Base32Error) -> Self {
+impl<E: core::fmt::Debug> core::error::Error for Base32Error<E> {}
+impl<E: core::fmt::Debug> From<Base32Error<E>> for Error<E> {
+    fn from(err: Base32Error<E>) -> Self {
         Error::Base32Error(err)
     }
 }

--- a/crates/ferroid/src/base32/error.rs
+++ b/crates/ferroid/src/base32/error.rs
@@ -10,15 +10,15 @@ pub enum Base32Error<E> {
 impl<E: core::fmt::Debug> fmt::Display for Base32Error<E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Base32Error::DecodeInvalidAscii(b) => write!(f, "invalid ascii byte: {b}"),
-            Base32Error::DecodeInvalidLen(len) => write!(f, "invalid length: {len}"),
-            Base32Error::DecodeOverflow(bytes) => write!(f, "decode overflow: {bytes:X?}"),
+            Self::DecodeInvalidAscii(b) => write!(f, "invalid ascii byte: {b}"),
+            Self::DecodeInvalidLen(len) => write!(f, "invalid length: {len}"),
+            Self::DecodeOverflow(bytes) => write!(f, "decode overflow: {bytes:X?}"),
         }
     }
 }
 impl<E: core::fmt::Debug> core::error::Error for Base32Error<E> {}
 impl<E: core::fmt::Debug> From<Base32Error<E>> for Error<E> {
     fn from(err: Base32Error<E>) -> Self {
-        Error::Base32Error(err)
+        Self::Base32Error(err)
     }
 }

--- a/crates/ferroid/src/base32/interface.rs
+++ b/crates/ferroid/src/base32/interface.rs
@@ -63,7 +63,7 @@ where
     /// - contains invalid ASCII characters (i.e., not in the Crockford Base32
     ///   alphabet)
     #[inline]
-    fn inner_decode<E>(s: impl AsRef<str>) -> Result<Self, E> {
+    fn inner_decode<E>(s: impl AsRef<str>) -> Result<Self, Error<E>> {
         let s_ref = s.as_ref();
         if s_ref.len() != Self::Ty::BASE32_SIZE {
             return Err(Error::Base32Error(Base32Error::DecodeInvalidLen(

--- a/crates/ferroid/src/base32/interface.rs
+++ b/crates/ferroid/src/base32/interface.rs
@@ -17,7 +17,7 @@ use crate::{Base32Error, BeBytes, Error, Id, Result};
 /// - Fixed-width, lexicographically sortable output
 /// - ASCII-safe encoding using Crockford's Base32 alphabet
 /// - Fallible decoding with strong validation
-pub(crate) trait Base32Ext: Id
+pub trait Base32Ext: Id
 where
     Self::Ty: BeBytes,
 {

--- a/crates/ferroid/src/base32/interface.rs
+++ b/crates/ferroid/src/base32/interface.rs
@@ -63,7 +63,7 @@ where
     /// - contains invalid ASCII characters (i.e., not in the Crockford Base32
     ///   alphabet)
     #[inline]
-    fn inner_decode(s: impl AsRef<str>) -> Result<Self> {
+    fn inner_decode<E>(s: impl AsRef<str>) -> Result<Self, E> {
         let s_ref = s.as_ref();
         if s_ref.len() != Self::Ty::BASE32_SIZE {
             return Err(Error::Base32Error(Base32Error::DecodeInvalidLen(

--- a/crates/ferroid/src/base32/mod.rs
+++ b/crates/ferroid/src/base32/mod.rs
@@ -9,7 +9,7 @@ mod snowflake;
 mod ulid;
 
 pub use be_bytes::*;
-use crockford::*;
+use crockford::{decode_base32, encode_base32};
 pub use error::*;
 #[cfg(feature = "snowflake")]
 pub use snowflake::*;

--- a/crates/ferroid/src/base32/snowflake.rs
+++ b/crates/ferroid/src/base32/snowflake.rs
@@ -33,6 +33,7 @@ where
     /// integer type.
     ///
     /// See also: [`Base32SnowExt::encode_to_buf`] for usage.
+    #[must_use]
     fn buf() -> <<Self as Id>::Ty as BeBytes>::Base32Array {
         <Self as Base32Ext>::inner_buf()
     }
@@ -89,7 +90,7 @@ where
     }
     /// Decodes a Base32-encoded string back into an ID.
     ///
-    /// ⚠️ **Note:**  
+    /// ⚠️ **Note:**\
     /// This method structurally decodes a Crockford base32 string into an
     /// integer representing a Snowflake ID, regardless of whether the input is
     /// a canonical Snowflake ID.
@@ -209,7 +210,7 @@ where
     }
 
     /// Consumes the builder and returns the raw buffer.
-    pub fn into_inner(self) -> <T::Ty as BeBytes>::Base32Array {
+    pub const fn into_inner(self) -> <T::Ty as BeBytes>::Base32Array {
         self.buf
     }
 }
@@ -276,6 +277,7 @@ where
     }
 
     /// Returns a `&str` view of the base32 encoding.
+    #[must_use]
     pub fn as_str(&self) -> &str {
         // SAFETY: `self.buf` holds only valid Crockford Base32 ASCII characters
         unsafe { core::str::from_utf8_unchecked(self.buf.as_ref()) }
@@ -285,13 +287,14 @@ where
     #[cfg(feature = "alloc")]
     #[cfg_attr(not(feature = "alloc"), doc(hidden))]
     #[allow(clippy::inherent_to_string_shadow_display)]
+    #[must_use]
     pub fn to_string(&self) -> alloc::string::String {
         // SAFETY: `self.buf` holds only valid Crockford Base32 ASCII characters
         unsafe { alloc::string::String::from_utf8_unchecked(self.buf.as_ref().to_vec()) }
     }
 }
 
-impl<'a, T: Base32SnowExt> fmt::Display for Base32SnowFormatterRef<'a, T>
+impl<T: Base32SnowExt> fmt::Display for Base32SnowFormatterRef<'_, T>
 where
     T::Ty: BeBytes,
 {
@@ -300,7 +303,7 @@ where
     }
 }
 
-impl<'a, T: Base32SnowExt> AsRef<str> for Base32SnowFormatterRef<'a, T>
+impl<T: Base32SnowExt> AsRef<str> for Base32SnowFormatterRef<'_, T>
 where
     T::Ty: BeBytes,
 {
@@ -309,7 +312,7 @@ where
     }
 }
 
-impl<'a, T: Base32SnowExt> PartialEq<str> for Base32SnowFormatterRef<'a, T>
+impl<T: Base32SnowExt> PartialEq<str> for Base32SnowFormatterRef<'_, T>
 where
     T::Ty: BeBytes,
 {
@@ -317,7 +320,7 @@ where
         self.as_str() == other
     }
 }
-impl<'a, T: Base32SnowExt> PartialEq<&str> for Base32SnowFormatterRef<'a, T>
+impl<T: Base32SnowExt> PartialEq<&str> for Base32SnowFormatterRef<'_, T>
 where
     T::Ty: BeBytes,
 {
@@ -328,7 +331,7 @@ where
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(not(feature = "alloc"), doc(hidden))]
-impl<'a, T: Base32SnowExt> PartialEq<alloc::string::String> for Base32SnowFormatterRef<'a, T>
+impl<T: Base32SnowExt> PartialEq<alloc::string::String> for Base32SnowFormatterRef<'_, T>
 where
     T::Ty: BeBytes,
 {

--- a/crates/ferroid/src/base32/snowflake.rs
+++ b/crates/ferroid/src/base32/snowflake.rs
@@ -277,7 +277,6 @@ where
     }
 
     /// Returns a `&str` view of the base32 encoding.
-    #[must_use]
     pub fn as_str(&self) -> &str {
         // SAFETY: `self.buf` holds only valid Crockford Base32 ASCII characters
         unsafe { core::str::from_utf8_unchecked(self.buf.as_ref()) }
@@ -287,7 +286,6 @@ where
     #[cfg(feature = "alloc")]
     #[cfg_attr(not(feature = "alloc"), doc(hidden))]
     #[allow(clippy::inherent_to_string_shadow_display)]
-    #[must_use]
     pub fn to_string(&self) -> alloc::string::String {
         // SAFETY: `self.buf` holds only valid Crockford Base32 ASCII characters
         unsafe { alloc::string::String::from_utf8_unchecked(self.buf.as_ref().to_vec()) }

--- a/crates/ferroid/src/base32/snowflake.rs
+++ b/crates/ferroid/src/base32/snowflake.rs
@@ -195,6 +195,7 @@ where
     }
 
     /// Returns a `&str` view of the base32 encoding.
+    #[must_use]
     pub fn as_str(&self) -> &str {
         // SAFETY: `self.buf` holds only valid Crockford Base32 ASCII characters
         unsafe { core::str::from_utf8_unchecked(self.buf.as_ref()) }
@@ -204,6 +205,7 @@ where
     #[cfg(feature = "alloc")]
     #[cfg_attr(not(feature = "alloc"), doc(hidden))]
     #[allow(clippy::inherent_to_string_shadow_display)]
+    #[must_use]
     pub fn to_string(&self) -> alloc::string::String {
         // SAFETY: `self.buf` holds only valid Crockford Base32 ASCII characters
         unsafe { alloc::string::String::from_utf8_unchecked(self.buf.as_ref().to_vec()) }
@@ -277,6 +279,7 @@ where
     }
 
     /// Returns a `&str` view of the base32 encoding.
+    #[must_use]
     pub fn as_str(&self) -> &str {
         // SAFETY: `self.buf` holds only valid Crockford Base32 ASCII characters
         unsafe { core::str::from_utf8_unchecked(self.buf.as_ref()) }
@@ -286,6 +289,7 @@ where
     #[cfg(feature = "alloc")]
     #[cfg_attr(not(feature = "alloc"), doc(hidden))]
     #[allow(clippy::inherent_to_string_shadow_display)]
+    #[must_use]
     pub fn to_string(&self) -> alloc::string::String {
         // SAFETY: `self.buf` holds only valid Crockford Base32 ASCII characters
         unsafe { alloc::string::String::from_utf8_unchecked(self.buf.as_ref().to_vec()) }

--- a/crates/ferroid/src/base32/snowflake.rs
+++ b/crates/ferroid/src/base32/snowflake.rs
@@ -202,6 +202,7 @@ where
     /// Returns an allocated `String` of the base32 encoding.
     #[cfg(feature = "alloc")]
     #[cfg_attr(not(feature = "alloc"), doc(hidden))]
+    #[allow(clippy::inherent_to_string_shadow_display)]
     pub fn to_string(&self) -> alloc::string::String {
         // SAFETY: `self.buf` holds only valid Crockford Base32 ASCII characters
         unsafe { alloc::string::String::from_utf8_unchecked(self.buf.as_ref().to_vec()) }
@@ -283,6 +284,7 @@ where
     /// Returns an allocated `String` of the base32 encoding.
     #[cfg(feature = "alloc")]
     #[cfg_attr(not(feature = "alloc"), doc(hidden))]
+    #[allow(clippy::inherent_to_string_shadow_display)]
     pub fn to_string(&self) -> alloc::string::String {
         // SAFETY: `self.buf` holds only valid Crockford Base32 ASCII characters
         unsafe { alloc::string::String::from_utf8_unchecked(self.buf.as_ref().to_vec()) }

--- a/crates/ferroid/src/base32/snowflake.rs
+++ b/crates/ferroid/src/base32/snowflake.rs
@@ -154,7 +154,7 @@ where
     ///     }).expect("should produce a valid ID");
     /// }
     /// ```
-    fn decode(s: impl AsRef<str>) -> Result<Self, Self> {
+    fn decode(s: impl AsRef<str>) -> Result<Self, Error<Self>> {
         let decoded = Self::inner_decode(s)?;
         if !decoded.is_valid() {
             return Err(Error::Base32Error(Base32Error::DecodeOverflow(decoded)));

--- a/crates/ferroid/src/base32/snowflake.rs
+++ b/crates/ferroid/src/base32/snowflake.rs
@@ -1,5 +1,5 @@
 use super::interface::Base32Ext;
-use crate::{Base32Error, BeBytes, Error, Id, Result, Snowflake};
+use crate::{Base32Error, BeBytes, Error, Id, Result, SnowflakeId};
 use core::fmt;
 use core::marker::PhantomData;
 
@@ -20,7 +20,7 @@ use core::marker::PhantomData;
 /// - Fixed-width, lexicographically sortable output
 /// - ASCII-safe encoding using Crockford's Base32 alphabet
 /// - Fallible decoding with strong validation
-pub trait Base32SnowExt: Snowflake
+pub trait Base32SnowExt: SnowflakeId
 where
     Self::Ty: BeBytes,
 {
@@ -122,7 +122,7 @@ where
     /// ```
     /// #[cfg(all(feature = "base32", feature = "snowflake"))]
     /// {
-    ///     use ferroid::{Base32SnowExt, Snowflake, SnowflakeTwitterId, Error, Base32Error, Id};
+    ///     use ferroid::{Base32SnowExt, SnowflakeId, SnowflakeTwitterId, Error, Base32Error, Id};
     ///
     ///     // Crockford base32 encodes in 5-bit chunks, so encoding a u64 (64 bits)
     ///     // requires 13 characters (13 * 5 = 65 bits). The highest (leftmost) bit
@@ -165,7 +165,7 @@ where
 
 impl<ID> Base32SnowExt for ID
 where
-    ID: Snowflake,
+    ID: SnowflakeId,
     ID::Ty: BeBytes,
 {
 }
@@ -345,7 +345,7 @@ where
 #[cfg(all(test, feature = "snowflake"))]
 mod test {
     use crate::{
-        Base32Error, Base32SnowExt, Error, Snowflake, SnowflakeDiscordId, SnowflakeInstagramId,
+        Base32Error, Base32SnowExt, Error, SnowflakeDiscordId, SnowflakeId, SnowflakeInstagramId,
         SnowflakeMastodonId, SnowflakeTwitterId,
     };
 

--- a/crates/ferroid/src/base32/ulid.rs
+++ b/crates/ferroid/src/base32/ulid.rs
@@ -136,12 +136,10 @@ where
     ///     assert!(ULID::decode("ZZZZZZZZZZZZZZZZZZZZZZZZZZ").is_ok());
     /// }
     /// ```
-    fn decode(s: impl AsRef<str>) -> Result<Self> {
+    fn decode(s: impl AsRef<str>) -> Result<Self, Self> {
         let decoded = Self::inner_decode(s)?;
         if !decoded.is_valid() {
-            return Err(Error::Base32Error(Base32Error::DecodeOverflow(
-                decoded.to_raw().to_be_bytes().as_ref().to_vec(),
-            )));
+            return Err(Error::Base32Error(Base32Error::DecodeOverflow(decoded)));
         }
         Ok(decoded)
     }
@@ -184,10 +182,12 @@ where
         unsafe { core::str::from_utf8_unchecked(self.buf.as_ref()) }
     }
 
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(not(feature = "alloc"), doc(hidden))]
     /// Returns an allocated `String` of the base32 encoding.
-    pub fn to_string(&self) -> String {
+    pub fn to_string(&self) -> alloc::string::String {
         // SAFETY: `self.buf` holds only valid Crockford Base32 ASCII characters
-        unsafe { String::from_utf8_unchecked(self.buf.as_ref().to_vec()) }
+        unsafe { alloc::string::String::from_utf8_unchecked(self.buf.as_ref().to_vec()) }
     }
 
     /// Consumes the builder and returns the raw buffer.
@@ -223,11 +223,13 @@ where
     }
 }
 
-impl<T: Base32UlidExt> PartialEq<String> for Base32UlidFormatter<T>
+#[cfg(feature = "alloc")]
+#[cfg_attr(not(feature = "alloc"), doc(hidden))]
+impl<T: Base32UlidExt> PartialEq<alloc::string::String> for Base32UlidFormatter<T>
 where
     T::Ty: BeBytes,
 {
-    fn eq(&self, other: &String) -> bool {
+    fn eq(&self, other: &alloc::string::String) -> bool {
         self.as_str() == other.as_str()
     }
 }
@@ -261,10 +263,12 @@ where
         unsafe { core::str::from_utf8_unchecked(self.buf.as_ref()) }
     }
 
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(not(feature = "alloc"), doc(hidden))]
     /// Returns an allocated `String` of the base32 encoding.
-    pub fn to_string(&self) -> String {
+    pub fn to_string(&self) -> alloc::string::String {
         // SAFETY: `self.buf` holds only valid Crockford Base32 ASCII characters
-        unsafe { String::from_utf8_unchecked(self.buf.as_ref().to_vec()) }
+        unsafe { alloc::string::String::from_utf8_unchecked(self.buf.as_ref().to_vec()) }
     }
 }
 
@@ -303,11 +307,13 @@ where
     }
 }
 
-impl<'a, T: Base32UlidExt> PartialEq<String> for Base32UlidFormatterRef<'a, T>
+#[cfg(feature = "alloc")]
+#[cfg_attr(not(feature = "alloc"), doc(hidden))]
+impl<'a, T: Base32UlidExt> PartialEq<alloc::string::String> for Base32UlidFormatterRef<'a, T>
 where
     T::Ty: BeBytes,
 {
-    fn eq(&self, other: &String) -> bool {
+    fn eq(&self, other: &alloc::string::String) -> bool {
         self.as_str() == other.as_str()
     }
 }

--- a/crates/ferroid/src/base32/ulid.rs
+++ b/crates/ferroid/src/base32/ulid.rs
@@ -1,5 +1,5 @@
 use super::interface::Base32Ext;
-use crate::{Base32Error, BeBytes, Error, Id, Result, Ulid};
+use crate::{Base32Error, BeBytes, Error, Id, Result, UlidId};
 use core::fmt;
 use core::marker::PhantomData;
 
@@ -20,7 +20,7 @@ use core::marker::PhantomData;
 /// - Fixed-width, lexicographically sortable output
 /// - ASCII-safe encoding using Crockford's Base32 alphabet
 /// - Fallible decoding with strong validation
-pub trait Base32UlidExt: Ulid
+pub trait Base32UlidExt: UlidId
 where
     Self::Ty: BeBytes,
 {
@@ -123,7 +123,7 @@ where
     /// ```
     /// #[cfg(all(feature = "base32", feature = "ulid"))]
     /// {
-    ///     use ferroid::{Base32UlidExt, Ulid, ULID};
+    ///     use ferroid::{Base32UlidExt, UlidId, ULID};
     ///     // Crockford base32 encodes in 5-bit chunks, so encoding a 128-bit ULID
     ///     // requires 26 characters (26 * 5 = 130 bits). The two highest (leftmost)
     ///     // bits from base32 encoding are always truncated (ignored) for performance.
@@ -148,7 +148,7 @@ where
 
 impl<ID> Base32UlidExt for ID
 where
-    ID: Ulid,
+    ID: UlidId,
     ID::Ty: BeBytes,
 {
 }
@@ -327,7 +327,7 @@ where
 
 #[cfg(all(test, feature = "ulid"))]
 mod test {
-    use crate::{Base32UlidExt, ULID, Ulid};
+    use crate::{Base32UlidExt, ULID, UlidId};
 
     #[test]
     fn ulid_max() {

--- a/crates/ferroid/src/base32/ulid.rs
+++ b/crates/ferroid/src/base32/ulid.rs
@@ -33,6 +33,7 @@ where
     /// integer type.
     ///
     /// See also: [`Base32UlidExt::encode_to_buf`] for usage.
+    #[must_use]
     fn buf() -> <<Self as Id>::Ty as BeBytes>::Base32Array {
         <Self as Base32Ext>::inner_buf()
     }
@@ -89,7 +90,7 @@ where
     }
     /// Decodes a Base32-encoded string back into an ID.
     ///
-    /// ⚠️ **Note:**  
+    /// ⚠️ **Note:**\
     /// This method structurally decodes a Crockford base32 string into an
     /// integer representing a ULID, regardless of whether the input is a
     /// canonical ULID.
@@ -192,7 +193,7 @@ where
     }
 
     /// Consumes the builder and returns the raw buffer.
-    pub fn into_inner(self) -> <T::Ty as BeBytes>::Base32Array {
+    pub const fn into_inner(self) -> <T::Ty as BeBytes>::Base32Array {
         self.buf
     }
 }
@@ -259,6 +260,7 @@ where
     }
 
     /// Returns a `&str` view of the base32 encoding.
+    #[must_use]
     pub fn as_str(&self) -> &str {
         // SAFETY: `self.buf` holds only valid Crockford Base32 ASCII characters
         unsafe { core::str::from_utf8_unchecked(self.buf.as_ref()) }
@@ -268,13 +270,14 @@ where
     #[cfg(feature = "alloc")]
     #[cfg_attr(not(feature = "alloc"), doc(hidden))]
     #[allow(clippy::inherent_to_string_shadow_display)]
+    #[must_use]
     pub fn to_string(&self) -> alloc::string::String {
         // SAFETY: `self.buf` holds only valid Crockford Base32 ASCII characters
         unsafe { alloc::string::String::from_utf8_unchecked(self.buf.as_ref().to_vec()) }
     }
 }
 
-impl<'a, T: Base32UlidExt> fmt::Display for Base32UlidFormatterRef<'a, T>
+impl<T: Base32UlidExt> fmt::Display for Base32UlidFormatterRef<'_, T>
 where
     T::Ty: BeBytes,
 {
@@ -283,7 +286,7 @@ where
     }
 }
 
-impl<'a, T: Base32UlidExt> AsRef<str> for Base32UlidFormatterRef<'a, T>
+impl<T: Base32UlidExt> AsRef<str> for Base32UlidFormatterRef<'_, T>
 where
     T::Ty: BeBytes,
 {
@@ -292,7 +295,7 @@ where
     }
 }
 
-impl<'a, T: Base32UlidExt> PartialEq<str> for Base32UlidFormatterRef<'a, T>
+impl<T: Base32UlidExt> PartialEq<str> for Base32UlidFormatterRef<'_, T>
 where
     T::Ty: BeBytes,
 {
@@ -300,7 +303,7 @@ where
         self.as_str() == other
     }
 }
-impl<'a, T: Base32UlidExt> PartialEq<&str> for Base32UlidFormatterRef<'a, T>
+impl<T: Base32UlidExt> PartialEq<&str> for Base32UlidFormatterRef<'_, T>
 where
     T::Ty: BeBytes,
 {
@@ -311,7 +314,7 @@ where
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(not(feature = "alloc"), doc(hidden))]
-impl<'a, T: Base32UlidExt> PartialEq<alloc::string::String> for Base32UlidFormatterRef<'a, T>
+impl<T: Base32UlidExt> PartialEq<alloc::string::String> for Base32UlidFormatterRef<'_, T>
 where
     T::Ty: BeBytes,
 {
@@ -341,28 +344,28 @@ mod test {
 
     #[test]
     fn ulid_known() {
-        let id = ULID::from_components(1469922850259, 1012768647078601740696923);
-        assert_eq!(id.timestamp(), 1469922850259);
-        assert_eq!(id.random(), 1012768647078601740696923);
+        let id = ULID::from_components(1_469_922_850_259, 1_012_768_647_078_601_740_696_923);
+        assert_eq!(id.timestamp(), 1_469_922_850_259);
+        assert_eq!(id.random(), 1_012_768_647_078_601_740_696_923);
 
         let encoded = id.encode();
         assert_eq!(encoded, "01ARZ3NDEKTSV4RRFFQ69G5FAV");
         let decoded = ULID::decode(encoded).unwrap();
 
-        assert_eq!(decoded.timestamp(), 1469922850259);
-        assert_eq!(decoded.random(), 1012768647078601740696923);
+        assert_eq!(decoded.timestamp(), 1_469_922_850_259);
+        assert_eq!(decoded.random(), 1_012_768_647_078_601_740_696_923);
         assert_eq!(id, decoded);
 
-        let id = ULID::from_components(1611559180765, 885339478614498720052741);
-        assert_eq!(id.timestamp(), 1611559180765);
-        assert_eq!(id.random(), 885339478614498720052741);
+        let id = ULID::from_components(1_611_559_180_765, 885_339_478_614_498_720_052_741);
+        assert_eq!(id.timestamp(), 1_611_559_180_765);
+        assert_eq!(id.random(), 885_339_478_614_498_720_052_741);
 
         let encoded = id.encode();
         assert_eq!(encoded, "01EWW6K6EXQDX5JV0E9CAHPXG5");
         let decoded = ULID::decode(encoded).unwrap();
 
-        assert_eq!(decoded.timestamp(), 1611559180765);
-        assert_eq!(decoded.random(), 885339478614498720052741);
+        assert_eq!(decoded.timestamp(), 1_611_559_180_765);
+        assert_eq!(decoded.random(), 885_339_478_614_498_720_052_741);
         assert_eq!(id, decoded);
     }
 

--- a/crates/ferroid/src/base32/ulid.rs
+++ b/crates/ferroid/src/base32/ulid.rs
@@ -182,9 +182,10 @@ where
         unsafe { core::str::from_utf8_unchecked(self.buf.as_ref()) }
     }
 
+    /// Returns an allocated `String` of the base32 encoding.
     #[cfg(feature = "alloc")]
     #[cfg_attr(not(feature = "alloc"), doc(hidden))]
-    /// Returns an allocated `String` of the base32 encoding.
+    #[allow(clippy::inherent_to_string_shadow_display)]
     pub fn to_string(&self) -> alloc::string::String {
         // SAFETY: `self.buf` holds only valid Crockford Base32 ASCII characters
         unsafe { alloc::string::String::from_utf8_unchecked(self.buf.as_ref().to_vec()) }
@@ -263,9 +264,10 @@ where
         unsafe { core::str::from_utf8_unchecked(self.buf.as_ref()) }
     }
 
+    /// Returns an allocated `String` of the base32 encoding.
     #[cfg(feature = "alloc")]
     #[cfg_attr(not(feature = "alloc"), doc(hidden))]
-    /// Returns an allocated `String` of the base32 encoding.
+    #[allow(clippy::inherent_to_string_shadow_display)]
     pub fn to_string(&self) -> alloc::string::String {
         // SAFETY: `self.buf` holds only valid Crockford Base32 ASCII characters
         unsafe { alloc::string::String::from_utf8_unchecked(self.buf.as_ref().to_vec()) }

--- a/crates/ferroid/src/base32/ulid.rs
+++ b/crates/ferroid/src/base32/ulid.rs
@@ -260,7 +260,6 @@ where
     }
 
     /// Returns a `&str` view of the base32 encoding.
-    #[must_use]
     pub fn as_str(&self) -> &str {
         // SAFETY: `self.buf` holds only valid Crockford Base32 ASCII characters
         unsafe { core::str::from_utf8_unchecked(self.buf.as_ref()) }
@@ -270,7 +269,6 @@ where
     #[cfg(feature = "alloc")]
     #[cfg_attr(not(feature = "alloc"), doc(hidden))]
     #[allow(clippy::inherent_to_string_shadow_display)]
-    #[must_use]
     pub fn to_string(&self) -> alloc::string::String {
         // SAFETY: `self.buf` holds only valid Crockford Base32 ASCII characters
         unsafe { alloc::string::String::from_utf8_unchecked(self.buf.as_ref().to_vec()) }

--- a/crates/ferroid/src/base32/ulid.rs
+++ b/crates/ferroid/src/base32/ulid.rs
@@ -178,6 +178,7 @@ where
     }
 
     /// Returns a `&str` view of the base32 encoding.
+    #[must_use]
     pub fn as_str(&self) -> &str {
         // SAFETY: `self.buf` holds only valid Crockford Base32 ASCII characters
         unsafe { core::str::from_utf8_unchecked(self.buf.as_ref()) }
@@ -187,6 +188,7 @@ where
     #[cfg(feature = "alloc")]
     #[cfg_attr(not(feature = "alloc"), doc(hidden))]
     #[allow(clippy::inherent_to_string_shadow_display)]
+    #[must_use]
     pub fn to_string(&self) -> alloc::string::String {
         // SAFETY: `self.buf` holds only valid Crockford Base32 ASCII characters
         unsafe { alloc::string::String::from_utf8_unchecked(self.buf.as_ref().to_vec()) }
@@ -260,6 +262,7 @@ where
     }
 
     /// Returns a `&str` view of the base32 encoding.
+    #[must_use]
     pub fn as_str(&self) -> &str {
         // SAFETY: `self.buf` holds only valid Crockford Base32 ASCII characters
         unsafe { core::str::from_utf8_unchecked(self.buf.as_ref()) }
@@ -269,6 +272,7 @@ where
     #[cfg(feature = "alloc")]
     #[cfg_attr(not(feature = "alloc"), doc(hidden))]
     #[allow(clippy::inherent_to_string_shadow_display)]
+    #[must_use]
     pub fn to_string(&self) -> alloc::string::String {
         // SAFETY: `self.buf` holds only valid Crockford Base32 ASCII characters
         unsafe { alloc::string::String::from_utf8_unchecked(self.buf.as_ref().to_vec()) }

--- a/crates/ferroid/src/base32/ulid.rs
+++ b/crates/ferroid/src/base32/ulid.rs
@@ -137,7 +137,7 @@ where
     ///     assert!(ULID::decode("ZZZZZZZZZZZZZZZZZZZZZZZZZZ").is_ok());
     /// }
     /// ```
-    fn decode(s: impl AsRef<str>) -> Result<Self, Self> {
+    fn decode(s: impl AsRef<str>) -> Result<Self, Error<Self>> {
         let decoded = Self::inner_decode(s)?;
         if !decoded.is_valid() {
             return Err(Error::Base32Error(Base32Error::DecodeOverflow(decoded)));

--- a/crates/ferroid/src/error.rs
+++ b/crates/ferroid/src/error.rs
@@ -30,6 +30,6 @@ use std::sync::{MutexGuard, PoisonError};
 // Convert all poisoned lock errors to a simplified `LockPoisoned`
 impl<T, E: fmt::Debug> From<PoisonError<MutexGuard<'_, T>>> for Error<E> {
     fn from(_: PoisonError<MutexGuard<'_, T>>) -> Self {
-        Error::LockPoisoned(core::marker::PhantomData)
+        Self::LockPoisoned(core::marker::PhantomData)
     }
 }

--- a/crates/ferroid/src/error.rs
+++ b/crates/ferroid/src/error.rs
@@ -1,27 +1,35 @@
 use core::fmt;
-use std::sync::{MutexGuard, PoisonError};
 
-pub type Result<T> = core::result::Result<T, Error>;
+pub type Result<T, E = core::convert::Infallible> = core::result::Result<T, Error<E>>;
 
 #[derive(Clone, Debug)]
 #[non_exhaustive]
-pub enum Error {
-    LockPoisoned,
+pub enum Error<E = core::convert::Infallible> {
+    #[cfg(feature = "std")]
+    LockPoisoned(core::marker::PhantomData<E>),
     #[cfg(feature = "base32")]
-    Base32Error(crate::Base32Error),
+    Base32Error(crate::Base32Error<E>),
+    // If no_std and no base32, use a dummy `Infallible` variant. This keeps the
+    // API the same, but the user should never see this error surface in
+    // practice.
+    #[cfg(not(all(feature = "std", feature = "base32")))]
+    Infallible(core::marker::PhantomData<E>),
 }
 
-impl fmt::Display for Error {
+impl<E: fmt::Debug> fmt::Display for Error<E> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "{self:?}")
     }
 }
 
-impl core::error::Error for Error {}
+impl<E: fmt::Debug> core::error::Error for Error<E> {}
 
+#[cfg(feature = "std")]
+use std::sync::{MutexGuard, PoisonError};
+#[cfg(feature = "std")]
 // Convert all poisoned lock errors to a simplified `LockPoisoned`
-impl<T> From<PoisonError<MutexGuard<'_, T>>> for Error {
+impl<T, E: fmt::Debug> From<PoisonError<MutexGuard<'_, T>>> for Error<E> {
     fn from(_: PoisonError<MutexGuard<'_, T>>) -> Self {
-        Error::LockPoisoned
+        Error::LockPoisoned(core::marker::PhantomData)
     }
 }

--- a/crates/ferroid/src/error.rs
+++ b/crates/ferroid/src/error.rs
@@ -1,6 +1,7 @@
 use core::fmt;
 
-pub type Result<T, E = core::convert::Infallible> = core::result::Result<T, Error<E>>;
+/// A Result type that is infallible by default
+pub type Result<T, E = core::convert::Infallible> = core::result::Result<T, E>;
 
 #[derive(Clone, Debug)]
 #[non_exhaustive]

--- a/crates/ferroid/src/futures/snowflake.rs
+++ b/crates/ferroid/src/futures/snowflake.rs
@@ -81,7 +81,7 @@ where
     ///
     /// This does not immediately begin polling the generator; instead, it will
     /// attempt to produce an ID when `.poll()` is called.
-    pub fn new(generator: &'a G) -> Self {
+    pub const fn new(generator: &'a G) -> Self {
         Self {
             generator,
             sleep: None,
@@ -89,7 +89,7 @@ where
         }
     }
 }
-impl<'a, G, ID, T, S> Future for SnowflakeGeneratorFuture<'a, G, ID, T, S>
+impl<G, ID, T, S> Future for SnowflakeGeneratorFuture<'_, G, ID, T, S>
 where
     G: SnowflakeGenerator<ID, T>,
     ID: Snowflake,
@@ -114,7 +114,7 @@ where
                     this.sleep.set(None);
                 }
             }
-        };
+        }
         match this.generator.try_next_id()? {
             IdGenStatus::Ready { id } => Poll::Ready(Ok(id)),
             IdGenStatus::Pending { yield_for } => {

--- a/crates/ferroid/src/futures/snowflake.rs
+++ b/crates/ferroid/src/futures/snowflake.rs
@@ -1,6 +1,7 @@
 use super::SleepProvider;
 use crate::{IdGenStatus, Result, Snowflake, SnowflakeGenerator, TimeSource, ToU64};
 use core::{
+    fmt,
     future::Future,
     marker::PhantomData,
     pin::Pin,
@@ -22,6 +23,8 @@ where
     ID: Snowflake,
     T: TimeSource<ID::Ty>,
 {
+    type Err: fmt::Debug;
+
     /// Returns a future that resolves to the next available Snowflake ID.
     ///
     /// If the generator is not ready to issue a new ID immediately, the future
@@ -30,7 +33,7 @@ where
     /// # Errors
     ///
     /// This future may return an error if the generator encounters one.
-    fn try_next_id_async<S>(&self) -> impl Future<Output = Result<ID>>
+    fn try_next_id_async<S>(&self) -> impl Future<Output = Result<ID, Self::Err>>
     where
         S: SleepProvider;
 }
@@ -41,7 +44,9 @@ where
     ID: Snowflake,
     T: TimeSource<ID::Ty>,
 {
-    fn try_next_id_async<'a, S>(&'a self) -> impl Future<Output = Result<ID>>
+    type Err = G::Err;
+
+    fn try_next_id_async<'a, S>(&'a self) -> impl Future<Output = Result<ID, Self::Err>>
     where
         S: SleepProvider,
     {
@@ -96,7 +101,7 @@ where
     T: TimeSource<ID::Ty>,
     S: SleepProvider,
 {
-    type Output = Result<ID>;
+    type Output = Result<ID, G::Err>;
 
     /// Polls the generator for a new ID.
     ///

--- a/crates/ferroid/src/futures/snowflake.rs
+++ b/crates/ferroid/src/futures/snowflake.rs
@@ -40,12 +40,13 @@ where
 
 impl<G, ID, T> SnowflakeGeneratorAsyncExt<ID, T> for G
 where
-    G: SnowflakeGenerator<ID, T> + Sync,
-    ID: Snowflake + Send,
-    T: TimeSource<ID::Ty> + Send,
+    G: SnowflakeGenerator<ID, T>,
+    ID: Snowflake,
+    T: TimeSource<ID::Ty>,
 {
     type Err = G::Err;
 
+    #[allow(clippy::future_not_send)]
     fn try_next_id_async<'a, S>(&'a self) -> impl Future<Output = Result<ID, Self::Err>>
     where
         S: SleepProvider,

--- a/crates/ferroid/src/futures/snowflake.rs
+++ b/crates/ferroid/src/futures/snowflake.rs
@@ -1,5 +1,5 @@
 use super::SleepProvider;
-use crate::{IdGenStatus, Result, Snowflake, SnowflakeGenerator, TimeSource, ToU64};
+use crate::{IdGenStatus, Result, SnowflakeGenerator, SnowflakeId, TimeSource, ToU64};
 use core::{
     fmt,
     future::Future,
@@ -20,7 +20,7 @@ use pin_project_lite::pin_project;
 /// [`SleepProvider`] to yield when the generator is not yet ready.
 pub trait SnowflakeGeneratorAsyncExt<ID, T>
 where
-    ID: Snowflake,
+    ID: SnowflakeId,
     T: TimeSource<ID::Ty>,
 {
     type Err: fmt::Debug;
@@ -41,7 +41,7 @@ where
 impl<G, ID, T> SnowflakeGeneratorAsyncExt<ID, T> for G
 where
     G: SnowflakeGenerator<ID, T>,
-    ID: Snowflake,
+    ID: SnowflakeId,
     T: TimeSource<ID::Ty>,
 {
     type Err = G::Err;
@@ -65,7 +65,7 @@ pin_project! {
     pub struct SnowflakeGeneratorFuture<'a, G, ID, T, S>
     where
         G: SnowflakeGenerator<ID, T>,
-        ID: Snowflake,
+        ID: SnowflakeId,
         T: TimeSource<ID::Ty>,
         S: SleepProvider,
     {
@@ -79,7 +79,7 @@ pin_project! {
 impl<'a, G, ID, T, S> SnowflakeGeneratorFuture<'a, G, ID, T, S>
 where
     G: SnowflakeGenerator<ID, T>,
-    ID: Snowflake,
+    ID: SnowflakeId,
     T: TimeSource<ID::Ty>,
     S: SleepProvider,
 {
@@ -98,7 +98,7 @@ where
 impl<G, ID, T, S> Future for SnowflakeGeneratorFuture<'_, G, ID, T, S>
 where
     G: SnowflakeGenerator<ID, T>,
-    ID: Snowflake,
+    ID: SnowflakeId,
     T: TimeSource<ID::Ty>,
     S: SleepProvider,
 {

--- a/crates/ferroid/src/futures/snowflake.rs
+++ b/crates/ferroid/src/futures/snowflake.rs
@@ -40,9 +40,9 @@ where
 
 impl<G, ID, T> SnowflakeGeneratorAsyncExt<ID, T> for G
 where
-    G: SnowflakeGenerator<ID, T>,
-    ID: Snowflake,
-    T: TimeSource<ID::Ty>,
+    G: SnowflakeGenerator<ID, T> + Sync,
+    ID: Snowflake + Send,
+    T: TimeSource<ID::Ty> + Send,
 {
     type Err = G::Err;
 

--- a/crates/ferroid/src/futures/ulid.rs
+++ b/crates/ferroid/src/futures/ulid.rs
@@ -40,13 +40,14 @@ where
 
 impl<G, ID, T, R> UlidGeneratorAsyncExt<ID, T, R> for G
 where
-    G: UlidGenerator<ID, T, R> + Sync,
-    ID: Ulid + Send,
-    T: TimeSource<ID::Ty> + Send,
-    R: RandSource<ID::Ty> + Send,
+    G: UlidGenerator<ID, T, R>,
+    ID: Ulid,
+    T: TimeSource<ID::Ty>,
+    R: RandSource<ID::Ty>,
 {
     type Err = G::Err;
 
+    #[allow(clippy::future_not_send)]
     fn try_next_id_async<'a, S>(&'a self) -> impl Future<Output = Result<ID, Self::Err>>
     where
         S: SleepProvider,

--- a/crates/ferroid/src/futures/ulid.rs
+++ b/crates/ferroid/src/futures/ulid.rs
@@ -1,6 +1,7 @@
 use super::SleepProvider;
 use crate::{IdGenStatus, RandSource, Result, TimeSource, ToU64, Ulid, UlidGenerator};
 use core::{
+    fmt,
     future::Future,
     marker::PhantomData,
     pin::Pin,
@@ -22,6 +23,8 @@ where
     T: TimeSource<ID::Ty>,
     R: RandSource<ID::Ty>,
 {
+    type Err: fmt::Debug;
+
     /// Returns a future that resolves to the next available Snowflake ID.
     ///
     /// If the generator is not ready to issue a new ID immediately, the future
@@ -30,7 +33,7 @@ where
     /// # Errors
     ///
     /// This future may return an error if the generator encounters one.
-    fn try_next_id_async<S>(&self) -> impl Future<Output = Result<ID>>
+    fn try_next_id_async<S>(&self) -> impl Future<Output = Result<ID, Self::Err>>
     where
         S: SleepProvider;
 }
@@ -42,7 +45,9 @@ where
     T: TimeSource<ID::Ty>,
     R: RandSource<ID::Ty>,
 {
-    fn try_next_id_async<'a, S>(&'a self) -> impl Future<Output = Result<ID>>
+    type Err = G::Err;
+
+    fn try_next_id_async<'a, S>(&'a self) -> impl Future<Output = Result<ID, Self::Err>>
     where
         S: SleepProvider,
     {
@@ -101,7 +106,7 @@ where
     R: RandSource<ID::Ty>,
     S: SleepProvider,
 {
-    type Output = Result<ID>;
+    type Output = Result<ID, G::Err>;
 
     /// Polls the generator for a new ID.
     ///

--- a/crates/ferroid/src/futures/ulid.rs
+++ b/crates/ferroid/src/futures/ulid.rs
@@ -84,7 +84,7 @@ where
     ///
     /// This does not immediately begin polling the generator; instead, it will
     /// attempt to produce an ID when `.poll()` is called.
-    pub fn new(generator: &'a G) -> Self {
+    pub const fn new(generator: &'a G) -> Self {
         Self {
             generator,
             sleep: None,
@@ -93,7 +93,7 @@ where
     }
 }
 
-impl<'a, G, ID, T, R, S> Future for UlidGeneratorFuture<'a, G, ID, T, R, S>
+impl<G, ID, T, R, S> Future for UlidGeneratorFuture<'_, G, ID, T, R, S>
 where
     G: UlidGenerator<ID, T, R>,
     ID: Ulid,
@@ -119,7 +119,7 @@ where
                     this.sleep.set(None);
                 }
             }
-        };
+        }
         match this.generator.try_next_id()? {
             IdGenStatus::Ready { id } => Poll::Ready(Ok(id)),
             IdGenStatus::Pending { yield_for } => {

--- a/crates/ferroid/src/futures/ulid.rs
+++ b/crates/ferroid/src/futures/ulid.rs
@@ -40,10 +40,10 @@ where
 
 impl<G, ID, T, R> UlidGeneratorAsyncExt<ID, T, R> for G
 where
-    G: UlidGenerator<ID, T, R>,
-    ID: Ulid,
-    T: TimeSource<ID::Ty>,
-    R: RandSource<ID::Ty>,
+    G: UlidGenerator<ID, T, R> + Sync,
+    ID: Ulid + Send,
+    T: TimeSource<ID::Ty> + Send,
+    R: RandSource<ID::Ty> + Send,
 {
     type Err = G::Err;
 

--- a/crates/ferroid/src/futures/ulid.rs
+++ b/crates/ferroid/src/futures/ulid.rs
@@ -1,5 +1,5 @@
 use super::SleepProvider;
-use crate::{IdGenStatus, RandSource, Result, TimeSource, ToU64, Ulid, UlidGenerator};
+use crate::{IdGenStatus, RandSource, Result, TimeSource, ToU64, UlidGenerator, UlidId};
 use core::{
     fmt,
     future::Future,
@@ -19,7 +19,7 @@ use pin_project_lite::pin_project;
 /// [`SleepProvider`] to yield when the generator is not yet ready.
 pub trait UlidGeneratorAsyncExt<ID, T, R>
 where
-    ID: Ulid,
+    ID: UlidId,
     T: TimeSource<ID::Ty>,
     R: RandSource<ID::Ty>,
 {
@@ -41,7 +41,7 @@ where
 impl<G, ID, T, R> UlidGeneratorAsyncExt<ID, T, R> for G
 where
     G: UlidGenerator<ID, T, R>,
-    ID: Ulid,
+    ID: UlidId,
     T: TimeSource<ID::Ty>,
     R: RandSource<ID::Ty>,
 {
@@ -66,7 +66,7 @@ pin_project! {
     pub struct UlidGeneratorFuture<'a, G, ID, T, R, S>
     where
         G: UlidGenerator<ID, T, R>,
-        ID: Ulid,
+        ID: UlidId,
         T: TimeSource<ID::Ty>,
         R: RandSource<ID::Ty>,
         S: SleepProvider,
@@ -81,7 +81,7 @@ pin_project! {
 impl<'a, G, ID, T, R, S> UlidGeneratorFuture<'a, G, ID, T, R, S>
 where
     G: UlidGenerator<ID, T, R>,
-    ID: Ulid,
+    ID: UlidId,
     T: TimeSource<ID::Ty>,
     R: RandSource<ID::Ty>,
     S: SleepProvider,
@@ -102,7 +102,7 @@ where
 impl<G, ID, T, R, S> Future for UlidGeneratorFuture<'_, G, ID, T, R, S>
 where
     G: UlidGenerator<ID, T, R>,
-    ID: Ulid,
+    ID: UlidId,
     T: TimeSource<ID::Ty>,
     R: RandSource<ID::Ty>,
     S: SleepProvider,

--- a/crates/ferroid/src/generator/snowflake/atomic.rs
+++ b/crates/ferroid/src/generator/snowflake/atomic.rs
@@ -240,6 +240,8 @@ where
     ID: Snowflake<Ty = u64>,
     T: TimeSource<ID::Ty>,
 {
+    type Err = core::convert::Infallible;
+
     fn new(machine_id: ID::Ty, clock: T) -> Self {
         Self::new(machine_id, clock)
     }
@@ -248,7 +250,7 @@ where
         self.next_id()
     }
 
-    fn try_next_id(&self) -> Result<IdGenStatus<ID>> {
+    fn try_next_id(&self) -> Result<IdGenStatus<ID>, Self::Err> {
         self.try_next_id()
     }
 }

--- a/crates/ferroid/src/generator/snowflake/atomic.rs
+++ b/crates/ferroid/src/generator/snowflake/atomic.rs
@@ -71,10 +71,13 @@ where
     /// # Example
     ///
     /// ```
-    /// use ferroid::{AtomicSnowflakeGenerator, SnowflakeTwitterId, MonotonicClock};
+    /// #[cfg(all(feature = "std", feature = "alloc", feature = "snowflake"))]
+    /// {
+    ///     use ferroid::{AtomicSnowflakeGenerator, SnowflakeTwitterId, MonotonicClock};
     ///
-    /// let generator = AtomicSnowflakeGenerator::<SnowflakeTwitterId, _>::new(0, MonotonicClock::default());
-    /// let id = generator.next_id();
+    ///     let generator = AtomicSnowflakeGenerator::<SnowflakeTwitterId, _>::new(0, MonotonicClock::default());
+    ///     let id = generator.next_id();
+    /// }
     /// ```
     ///
     /// [`TimeSource`]: crate::TimeSource
@@ -131,20 +134,23 @@ where
     ///
     /// # Example
     /// ```
-    /// use ferroid::{AtomicSnowflakeGenerator, SnowflakeTwitterId, IdGenStatus, MonotonicClock, TimeSource};
+    /// #[cfg(all(feature = "std", feature = "alloc", feature = "snowflake"))]
+    /// {
+    ///     use ferroid::{AtomicSnowflakeGenerator, SnowflakeTwitterId, IdGenStatus, MonotonicClock, TimeSource};
     ///
-    /// // Create a clock and a generator with machine_id = 0
-    /// let clock = MonotonicClock::default();
-    /// let generator = AtomicSnowflakeGenerator::<SnowflakeTwitterId, _>::new(0, clock);
+    ///     // Create a clock and a generator with machine_id = 0
+    ///     let clock = MonotonicClock::default();
+    ///     let generator = AtomicSnowflakeGenerator::<SnowflakeTwitterId, _>::new(0, clock);
     ///
-    /// // Attempt to generate a new ID
-    /// match generator.next_id() {
-    ///     IdGenStatus::Ready { id } => {
-    ///         println!("ID: {}", id);
-    ///         assert_eq!(id.machine_id(), 0);
-    ///     }
-    ///     IdGenStatus::Pending { yield_for } => {
-    ///         println!("Exhausted; wait for: {}ms", yield_for);
+    ///     // Attempt to generate a new ID
+    ///     match generator.next_id() {
+    ///         IdGenStatus::Ready { id } => {
+    ///             println!("ID: {}", id);
+    ///             assert_eq!(id.machine_id(), 0);
+    ///         }
+    ///         IdGenStatus::Pending { yield_for } => {
+    ///             println!("Exhausted; wait for: {}ms", yield_for);
+    ///         }
     ///     }
     /// }
     /// ```
@@ -172,22 +178,25 @@ where
     ///
     /// # Example
     /// ```
-    /// use ferroid::{AtomicSnowflakeGenerator, SnowflakeTwitterId, IdGenStatus, MonotonicClock, TimeSource};
+    /// #[cfg(all(feature = "std", feature = "alloc", feature = "snowflake"))]
+    /// {
+    ///     use ferroid::{AtomicSnowflakeGenerator, SnowflakeTwitterId, IdGenStatus, MonotonicClock, TimeSource};
     ///
-    /// // Create a clock and a generator with machine_id = 0
-    /// let clock = MonotonicClock::default();
-    /// let generator = AtomicSnowflakeGenerator::<SnowflakeTwitterId, _>::new(0, clock);
+    ///     // Create a clock and a generator with machine_id = 0
+    ///     let clock = MonotonicClock::default();
+    ///     let generator = AtomicSnowflakeGenerator::<SnowflakeTwitterId, _>::new(0, clock);
     ///
-    /// // Attempt to generate a new ID
-    /// match generator.try_next_id() {
-    ///     Ok(IdGenStatus::Ready { id }) => {
-    ///         println!("ID: {}", id);
-    ///         assert_eq!(id.machine_id(), 0);
+    ///     // Attempt to generate a new ID
+    ///     match generator.try_next_id() {
+    ///         Ok(IdGenStatus::Ready { id }) => {
+    ///             println!("ID: {}", id);
+    ///             assert_eq!(id.machine_id(), 0);
+    ///         }
+    ///         Ok(IdGenStatus::Pending { yield_for }) => {
+    ///             println!("Exhausted; wait for: {}ms", yield_for);
+    ///         }
+    ///         Err(e) => eprintln!("Generator error: {}", e),
     ///     }
-    ///     Ok(IdGenStatus::Pending { yield_for }) => {
-    ///         println!("Exhausted; wait for: {}ms", yield_for);
-    ///     }
-    ///     Err(e) => eprintln!("Generator error: {}", e),
     /// }
     /// ```
     #[cfg_attr(feature = "tracing", instrument(level = "trace", skip(self)))]

--- a/crates/ferroid/src/generator/snowflake/atomic.rs
+++ b/crates/ferroid/src/generator/snowflake/atomic.rs
@@ -15,7 +15,7 @@ use tracing::instrument;
 /// ## Features
 ///
 /// - ✅ Thread-safe
-/// - ❌ Safely implement any [`Snowflake`] layout
+/// - ❌ Safely implement any [`SnowflakeId`] layout
 ///
 /// ## Caveats
 /// This implementation uses an `AtomicU64` internally, so it only supports ID

--- a/crates/ferroid/src/generator/snowflake/atomic.rs
+++ b/crates/ferroid/src/generator/snowflake/atomic.rs
@@ -1,4 +1,4 @@
-use crate::{IdGenStatus, Result, Snowflake, SnowflakeGenerator, TimeSource};
+use crate::{IdGenStatus, Result, SnowflakeId, SnowflakeGenerator, TimeSource};
 use core::{
     cmp,
     marker::PhantomData,
@@ -34,7 +34,7 @@ use tracing::instrument;
 /// [`LockSnowflakeGenerator`]: crate::LockSnowflakeGenerator
 pub struct AtomicSnowflakeGenerator<ID, T>
 where
-    ID: Snowflake<Ty = u64>,
+    ID: SnowflakeId<Ty = u64>,
     T: TimeSource<ID::Ty>,
 {
     state: AtomicU64,
@@ -45,7 +45,7 @@ where
 
 impl<ID, T> AtomicSnowflakeGenerator<ID, T>
 where
-    ID: Snowflake<Ty = u64>,
+    ID: SnowflakeId<Ty = u64>,
     T: TimeSource<ID::Ty>,
 {
     /// Creates a new [`AtomicSnowflakeGenerator`] initialized with the current
@@ -246,7 +246,7 @@ where
 
 impl<ID, T> SnowflakeGenerator<ID, T> for AtomicSnowflakeGenerator<ID, T>
 where
-    ID: Snowflake<Ty = u64>,
+    ID: SnowflakeId<Ty = u64>,
     T: TimeSource<ID::Ty>,
 {
     type Err = core::convert::Infallible;

--- a/crates/ferroid/src/generator/snowflake/atomic.rs
+++ b/crates/ferroid/src/generator/snowflake/atomic.rs
@@ -166,6 +166,10 @@ where
     ///   milliseconds) before trying again
     /// - `Err(e)`: A recoverable error occurred (e.g., time source failure)
     ///
+    /// # Errors
+    /// - This method currently does not return any errors and always returns
+    ///   `Ok`. It is marked as fallible to allow for future extensibility
+    ///
     /// # Example
     /// ```
     /// use ferroid::{AtomicSnowflakeGenerator, SnowflakeTwitterId, IdGenStatus, MonotonicClock, TimeSource};

--- a/crates/ferroid/src/generator/snowflake/basic.rs
+++ b/crates/ferroid/src/generator/snowflake/basic.rs
@@ -60,10 +60,13 @@ where
     /// # Example
     ///
     /// ```
-    /// use ferroid::{BasicSnowflakeGenerator, SnowflakeTwitterId, MonotonicClock};
+    /// #[cfg(all(feature = "std", feature = "alloc", feature = "snowflake"))]
+    /// {
+    ///     use ferroid::{BasicSnowflakeGenerator, SnowflakeTwitterId, MonotonicClock};
     ///
-    /// let generator = BasicSnowflakeGenerator::<SnowflakeTwitterId, _>::new(0, MonotonicClock::default());
-    /// let id = generator.next_id();
+    ///     let generator = BasicSnowflakeGenerator::<SnowflakeTwitterId, _>::new(0, MonotonicClock::default());
+    ///     let id = generator.next_id();
+    /// }
     /// ```
     ///
     /// [`TimeSource`]: crate::TimeSource
@@ -117,20 +120,23 @@ where
     ///
     /// # Example
     /// ```
-    /// use ferroid::{BasicSnowflakeGenerator, SnowflakeTwitterId, IdGenStatus, MonotonicClock, TimeSource};
+    /// #[cfg(all(feature = "std", feature = "alloc", feature = "snowflake"))]
+    /// {
+    ///     use ferroid::{BasicSnowflakeGenerator, SnowflakeTwitterId, IdGenStatus, MonotonicClock, TimeSource};
     ///
-    /// // Create a clock and a generator with machine_id = 0
-    /// let clock = MonotonicClock::default();
-    /// let generator = BasicSnowflakeGenerator::<SnowflakeTwitterId, _>::new(0, clock);
+    ///     // Create a clock and a generator with machine_id = 0
+    ///     let clock = MonotonicClock::default();
+    ///     let generator = BasicSnowflakeGenerator::<SnowflakeTwitterId, _>::new(0, clock);
     ///
-    /// // Attempt to generate a new ID
-    /// match generator.next_id() {
-    ///     IdGenStatus::Ready { id } => {
-    ///         println!("ID: {}", id);
-    ///         assert_eq!(id.machine_id(), 0);
-    ///     }
-    ///     IdGenStatus::Pending { yield_for } => {
-    ///         println!("Exhausted; wait for: {}ms", yield_for);
+    ///     // Attempt to generate a new ID
+    ///     match generator.next_id() {
+    ///         IdGenStatus::Ready { id } => {
+    ///             println!("ID: {}", id);
+    ///             assert_eq!(id.machine_id(), 0);
+    ///         }
+    ///         IdGenStatus::Pending { yield_for } => {
+    ///             println!("Exhausted; wait for: {}ms", yield_for);
+    ///         }
     ///     }
     /// }
     /// ```
@@ -158,22 +164,25 @@ where
     ///
     /// # Example
     /// ```
-    /// use ferroid::{BasicSnowflakeGenerator, SnowflakeTwitterId, IdGenStatus, MonotonicClock, TimeSource};
+    /// #[cfg(all(feature = "std", feature = "alloc", feature = "snowflake"))]
+    /// {
+    ///     use ferroid::{BasicSnowflakeGenerator, SnowflakeTwitterId, IdGenStatus, MonotonicClock, TimeSource};
     ///
-    /// // Create a clock and a generator with machine_id = 0
-    /// let clock = MonotonicClock::default();
-    /// let generator = BasicSnowflakeGenerator::<SnowflakeTwitterId, _>::new(0, clock);
+    ///     // Create a clock and a generator with machine_id = 0
+    ///     let clock = MonotonicClock::default();
+    ///     let generator = BasicSnowflakeGenerator::<SnowflakeTwitterId, _>::new(0, clock);
     ///
-    /// // Attempt to generate a new ID
-    /// match generator.try_next_id() {
-    ///     Ok(IdGenStatus::Ready { id }) => {
-    ///         println!("ID: {}", id);
-    ///         assert_eq!(id.machine_id(), 0);
+    ///     // Attempt to generate a new ID
+    ///     match generator.try_next_id() {
+    ///         Ok(IdGenStatus::Ready { id }) => {
+    ///             println!("ID: {}", id);
+    ///             assert_eq!(id.machine_id(), 0);
+    ///         }
+    ///         Ok(IdGenStatus::Pending { yield_for }) => {
+    ///             println!("Exhausted; wait for: {}ms", yield_for);
+    ///         }
+    ///         Err(e) => eprintln!("Generator error: {}", e),
     ///     }
-    ///     Ok(IdGenStatus::Pending { yield_for }) => {
-    ///         println!("Exhausted; wait for: {}ms", yield_for);
-    ///     }
-    ///     Err(e) => eprintln!("Generator error: {}", e),
     /// }
     /// ```
     #[cfg_attr(feature = "tracing", instrument(level = "trace", skip(self)))]

--- a/crates/ferroid/src/generator/snowflake/basic.rs
+++ b/crates/ferroid/src/generator/snowflake/basic.rs
@@ -152,6 +152,10 @@ where
     ///   milliseconds) before trying again
     /// - `Err(e)`: A recoverable error occurred (e.g., time source failure)
     ///
+    /// # Errors
+    /// - This method currently does not return any errors and always returns
+    ///   `Ok`. It is marked as fallible to allow for future extensibility
+    ///
     /// # Example
     /// ```
     /// use ferroid::{BasicSnowflakeGenerator, SnowflakeTwitterId, IdGenStatus, MonotonicClock, TimeSource};

--- a/crates/ferroid/src/generator/snowflake/basic.rs
+++ b/crates/ferroid/src/generator/snowflake/basic.rs
@@ -213,6 +213,8 @@ where
     ID: Snowflake,
     T: TimeSource<ID::Ty>,
 {
+    type Err = core::convert::Infallible;
+
     fn new(machine_id: ID::Ty, clock: T) -> Self {
         Self::new(machine_id, clock)
     }
@@ -221,7 +223,7 @@ where
         self.next_id()
     }
 
-    fn try_next_id(&self) -> Result<IdGenStatus<ID>> {
+    fn try_next_id(&self) -> Result<IdGenStatus<ID>, Self::Err> {
         self.try_next_id()
     }
 }

--- a/crates/ferroid/src/generator/snowflake/basic.rs
+++ b/crates/ferroid/src/generator/snowflake/basic.rs
@@ -1,4 +1,4 @@
-use crate::{IdGenStatus, Result, Snowflake, SnowflakeGenerator, TimeSource};
+use crate::{IdGenStatus, Result, SnowflakeGenerator, SnowflakeId, TimeSource};
 use core::{cell::Cell, cmp::Ordering};
 #[cfg(feature = "tracing")]
 use tracing::instrument;
@@ -25,7 +25,7 @@ use tracing::instrument;
 /// [`AtomicSnowflakeGenerator`]: crate::AtomicSnowflakeGenerator
 pub struct BasicSnowflakeGenerator<ID, T>
 where
-    ID: Snowflake,
+    ID: SnowflakeId,
     T: TimeSource<ID::Ty>,
 {
     state: Cell<ID>,
@@ -34,7 +34,7 @@ where
 
 impl<ID, T> BasicSnowflakeGenerator<ID, T>
 where
-    ID: Snowflake,
+    ID: SnowflakeId,
     T: TimeSource<ID::Ty>,
 {
     /// Creates a new [`BasicSnowflakeGenerator`] initialized with the current
@@ -219,7 +219,7 @@ where
 
 impl<ID, T> SnowflakeGenerator<ID, T> for BasicSnowflakeGenerator<ID, T>
 where
-    ID: Snowflake,
+    ID: SnowflakeId,
     T: TimeSource<ID::Ty>,
 {
     type Err = core::convert::Infallible;

--- a/crates/ferroid/src/generator/snowflake/basic.rs
+++ b/crates/ferroid/src/generator/snowflake/basic.rs
@@ -11,7 +11,7 @@ use tracing::instrument;
 /// ## Features
 ///
 /// - ❌ Not thread-safe
-/// - ✅ Safely implement any [`Snowflake`] layout
+/// - ✅ Safely implement any [`SnowflakeId`] layout
 ///
 /// ## Recommended When
 /// - You're in a single-threaded environment (no shared access)

--- a/crates/ferroid/src/generator/snowflake/interface.rs
+++ b/crates/ferroid/src/generator/snowflake/interface.rs
@@ -1,10 +1,10 @@
-use crate::{IdGenStatus, Result, Snowflake, TimeSource};
+use crate::{IdGenStatus, Result, SnowflakeId, TimeSource};
 use core::fmt;
 
 /// A minimal interface for generating Snowflake IDs
 pub trait SnowflakeGenerator<ID, T>
 where
-    ID: Snowflake,
+    ID: SnowflakeId,
     T: TimeSource<ID::Ty>,
 {
     type Err: fmt::Debug;

--- a/crates/ferroid/src/generator/snowflake/interface.rs
+++ b/crates/ferroid/src/generator/snowflake/interface.rs
@@ -1,4 +1,5 @@
 use crate::{IdGenStatus, Result, Snowflake, TimeSource};
+use core::fmt;
 
 /// A minimal interface for generating Snowflake IDs
 pub trait SnowflakeGenerator<ID, T>
@@ -6,6 +7,8 @@ where
     ID: Snowflake,
     T: TimeSource<ID::Ty>,
 {
+    type Err: fmt::Debug;
+
     // Creates a new generator
     fn new(machine_id: ID::Ty, clock: T) -> Self;
 
@@ -13,5 +16,9 @@ where
     fn next_id(&self) -> IdGenStatus<ID>;
 
     /// A fallible version of [`Self::next_id`] that returns a [`Result`].
-    fn try_next_id(&self) -> Result<IdGenStatus<ID>>;
+    ///
+    /// # Errors
+    /// - May return an error if the underlying generator uses a lock and it is
+    ///   poisoned.
+    fn try_next_id(&self) -> Result<IdGenStatus<ID>, Self::Err>;
 }

--- a/crates/ferroid/src/generator/snowflake/lock.rs
+++ b/crates/ferroid/src/generator/snowflake/lock.rs
@@ -154,6 +154,9 @@ where
     ///   milliseconds) before trying again
     /// - `Err(e)`: A recoverable error occurred (e.g., time source failure)
     ///
+    /// # Errors
+    /// - Returns an error if the underlying lock has been poisoned.
+    ///
     /// # Example
     /// ```
     /// use ferroid::{LockSnowflakeGenerator, SnowflakeTwitterId, IdGenStatus, MonotonicClock, TimeSource};

--- a/crates/ferroid/src/generator/snowflake/lock.rs
+++ b/crates/ferroid/src/generator/snowflake/lock.rs
@@ -1,4 +1,4 @@
-use crate::{Error, IdGenStatus, Result, Snowflake, SnowflakeGenerator, TimeSource};
+use crate::{Error, IdGenStatus, Result, SnowflakeId, SnowflakeGenerator, TimeSource};
 use alloc::sync::Arc;
 use core::cmp::Ordering;
 use std::sync::Mutex;
@@ -28,7 +28,7 @@ use tracing::instrument;
 /// [`AtomicSnowflakeGenerator`]: crate::AtomicSnowflakeGenerator
 pub struct LockSnowflakeGenerator<ID, T>
 where
-    ID: Snowflake,
+    ID: SnowflakeId,
     T: TimeSource<ID::Ty>,
 {
     state: Arc<Mutex<ID>>,
@@ -37,7 +37,7 @@ where
 
 impl<ID, T> LockSnowflakeGenerator<ID, T>
 where
-    ID: Snowflake,
+    ID: SnowflakeId,
     T: TimeSource<ID::Ty>,
 {
     /// Creates a new [`LockSnowflakeGenerator`] initialized with the current
@@ -218,7 +218,7 @@ where
 
 impl<ID, T> SnowflakeGenerator<ID, T> for LockSnowflakeGenerator<ID, T>
 where
-    ID: Snowflake,
+    ID: SnowflakeId,
     T: TimeSource<ID::Ty>,
 {
     type Err = Error;

--- a/crates/ferroid/src/generator/snowflake/lock.rs
+++ b/crates/ferroid/src/generator/snowflake/lock.rs
@@ -1,4 +1,4 @@
-use crate::{IdGenStatus, Result, Snowflake, SnowflakeGenerator, TimeSource};
+use crate::{Error, IdGenStatus, Result, Snowflake, SnowflakeGenerator, TimeSource};
 use alloc::sync::Arc;
 use core::cmp::Ordering;
 use std::sync::Mutex;
@@ -178,7 +178,7 @@ where
     /// }
     /// ```
     #[cfg_attr(feature = "tracing", instrument(level = "trace", skip(self)))]
-    pub fn try_next_id(&self) -> Result<IdGenStatus<ID>> {
+    pub fn try_next_id(&self) -> Result<IdGenStatus<ID>, Error<core::convert::Infallible>> {
         let now = self.time.current_millis();
         let mut id = self.state.lock()?;
         let current_ts = id.timestamp();
@@ -212,6 +212,8 @@ where
     ID: Snowflake,
     T: TimeSource<ID::Ty>,
 {
+    type Err = Error;
+
     fn new(machine_id: ID::Ty, clock: T) -> Self {
         Self::new(machine_id, clock)
     }
@@ -220,7 +222,7 @@ where
         self.next_id()
     }
 
-    fn try_next_id(&self) -> Result<IdGenStatus<ID>> {
+    fn try_next_id(&self) -> Result<IdGenStatus<ID>, Self::Err> {
         self.try_next_id()
     }
 }

--- a/crates/ferroid/src/generator/snowflake/lock.rs
+++ b/crates/ferroid/src/generator/snowflake/lock.rs
@@ -63,10 +63,13 @@ where
     /// # Example
     ///
     /// ```
-    /// use ferroid::{LockSnowflakeGenerator, SnowflakeTwitterId, MonotonicClock};
+    /// #[cfg(all(feature = "std", feature = "alloc", feature = "snowflake"))]
+    /// {
+    ///     use ferroid::{LockSnowflakeGenerator, SnowflakeTwitterId, MonotonicClock};
     ///
-    /// let generator = LockSnowflakeGenerator::<SnowflakeTwitterId, _>::new(0, MonotonicClock::default());
-    /// let id = generator.next_id();
+    ///     let generator = LockSnowflakeGenerator::<SnowflakeTwitterId, _>::new(0, MonotonicClock::default());
+    ///     let id = generator.next_id();
+    /// }
     /// ```
     ///
     /// [`TimeSource`]: crate::TimeSource
@@ -119,20 +122,23 @@ where
     ///
     /// # Example
     /// ```
-    /// use ferroid::{LockSnowflakeGenerator, SnowflakeTwitterId, IdGenStatus, MonotonicClock, TimeSource};
+    /// #[cfg(all(feature = "std", feature = "alloc", feature = "snowflake"))]
+    /// {
+    ///     use ferroid::{LockSnowflakeGenerator, SnowflakeTwitterId, IdGenStatus, MonotonicClock, TimeSource};
     ///
-    /// // Create a clock and a generator with machine_id = 0
-    /// let clock = MonotonicClock::default();
-    /// let generator = LockSnowflakeGenerator::<SnowflakeTwitterId, _>::new(0, clock);
+    ///     // Create a clock and a generator with machine_id = 0
+    ///     let clock = MonotonicClock::default();
+    ///     let generator = LockSnowflakeGenerator::<SnowflakeTwitterId, _>::new(0, clock);
     ///
-    /// // Attempt to generate a new ID
-    /// match generator.next_id() {
-    ///     IdGenStatus::Ready { id } => {
-    ///         println!("ID: {}", id);
-    ///         assert_eq!(id.machine_id(), 0);
-    ///     }
-    ///     IdGenStatus::Pending { yield_for } => {
-    ///         println!("Exhausted; wait for: {}ms", yield_for);
+    ///     // Attempt to generate a new ID
+    ///     match generator.next_id() {
+    ///         IdGenStatus::Ready { id } => {
+    ///             println!("ID: {}", id);
+    ///             assert_eq!(id.machine_id(), 0);
+    ///         }
+    ///         IdGenStatus::Pending { yield_for } => {
+    ///             println!("Exhausted; wait for: {}ms", yield_for);
+    ///         }
     ///     }
     /// }
     /// ```
@@ -159,22 +165,25 @@ where
     ///
     /// # Example
     /// ```
-    /// use ferroid::{LockSnowflakeGenerator, SnowflakeTwitterId, IdGenStatus, MonotonicClock, TimeSource};
+    /// #[cfg(all(feature = "std", feature = "alloc", feature = "snowflake"))]
+    /// {
+    ///     use ferroid::{LockSnowflakeGenerator, SnowflakeTwitterId, IdGenStatus, MonotonicClock, TimeSource};
     ///
-    /// // Create a clock and a generator with machine_id = 0
-    /// let clock = MonotonicClock::default();
-    /// let generator = LockSnowflakeGenerator::<SnowflakeTwitterId, _>::new(0, clock);
+    ///     // Create a clock and a generator with machine_id = 0
+    ///     let clock = MonotonicClock::default();
+    ///     let generator = LockSnowflakeGenerator::<SnowflakeTwitterId, _>::new(0, clock);
     ///
-    /// // Attempt to generate a new ID
-    /// match generator.try_next_id() {
-    ///     Ok(IdGenStatus::Ready { id }) => {
-    ///         println!("ID: {}", id);
-    ///         assert_eq!(id.machine_id(), 0);
+    ///     // Attempt to generate a new ID
+    ///     match generator.try_next_id() {
+    ///         Ok(IdGenStatus::Ready { id }) => {
+    ///             println!("ID: {}", id);
+    ///             assert_eq!(id.machine_id(), 0);
+    ///         }
+    ///         Ok(IdGenStatus::Pending { yield_for }) => {
+    ///             println!("Exhausted; wait for: {}ms", yield_for);
+    ///         }
+    ///         Err(e) => eprintln!("Generator error: {}", e),
     ///     }
-    ///     Ok(IdGenStatus::Pending { yield_for }) => {
-    ///         println!("Exhausted; wait for: {}ms", yield_for);
-    ///     }
-    ///     Err(e) => eprintln!("Generator error: {}", e),
     /// }
     /// ```
     #[cfg_attr(feature = "tracing", instrument(level = "trace", skip(self)))]

--- a/crates/ferroid/src/generator/snowflake/lock.rs
+++ b/crates/ferroid/src/generator/snowflake/lock.rs
@@ -1,6 +1,7 @@
 use crate::{IdGenStatus, Result, Snowflake, SnowflakeGenerator, TimeSource};
+use alloc::sync::Arc;
 use core::cmp::Ordering;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 #[cfg(feature = "tracing")]
 use tracing::instrument;
 

--- a/crates/ferroid/src/generator/snowflake/lock.rs
+++ b/crates/ferroid/src/generator/snowflake/lock.rs
@@ -1,4 +1,4 @@
-use crate::{Error, IdGenStatus, Result, SnowflakeId, SnowflakeGenerator, TimeSource};
+use crate::{Error, IdGenStatus, Result, SnowflakeGenerator, SnowflakeId, TimeSource};
 use alloc::sync::Arc;
 use core::cmp::Ordering;
 use std::sync::Mutex;
@@ -14,7 +14,7 @@ use tracing::instrument;
 /// ## Features
 ///
 /// - ✅ Thread-safe
-/// - ✅ Safely implement any [`Snowflake`] layout
+/// - ✅ Safely implement any [`SnowflakeId`] layout
 ///
 /// ## Recommended When
 /// - You're in a multi-threaded environment

--- a/crates/ferroid/src/generator/snowflake/mod.rs
+++ b/crates/ferroid/src/generator/snowflake/mod.rs
@@ -1,6 +1,7 @@
 mod atomic;
 mod basic;
 mod interface;
+#[cfg(all(feature = "std", feature = "alloc"))]
 mod lock;
 #[cfg(test)]
 mod tests;
@@ -8,4 +9,6 @@ mod tests;
 pub use atomic::*;
 pub use basic::*;
 pub use interface::*;
+
+#[cfg(all(feature = "std", feature = "alloc"))]
 pub use lock::*;

--- a/crates/ferroid/src/generator/snowflake/mod.rs
+++ b/crates/ferroid/src/generator/snowflake/mod.rs
@@ -3,7 +3,7 @@ mod basic;
 mod interface;
 #[cfg(all(feature = "std", feature = "alloc"))]
 mod lock;
-#[cfg(test)]
+#[cfg(all(test, feature = "std", feature = "alloc"))]
 mod tests;
 
 pub use atomic::*;

--- a/crates/ferroid/src/generator/snowflake/tests.rs
+++ b/crates/ferroid/src/generator/snowflake/tests.rs
@@ -2,10 +2,12 @@ use crate::{
     AtomicSnowflakeGenerator, BasicSnowflakeGenerator, Id, IdGenStatus, LockSnowflakeGenerator,
     MonotonicClock, Snowflake, SnowflakeGenerator, SnowflakeTwitterId, TimeSource, ToU64,
 };
+use alloc::rc::Rc;
+use alloc::sync::Arc;
+use alloc::{vec, vec::Vec};
 use core::cell::Cell;
 use std::collections::HashSet;
-use std::rc::Rc;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 use std::thread::scope;
 
 struct MockTime {

--- a/crates/ferroid/src/generator/snowflake/tests.rs
+++ b/crates/ferroid/src/generator/snowflake/tests.rs
@@ -106,7 +106,7 @@ where
     assert_eq!(yield_for, ID::ONE);
 }
 
-fn run_generator_handles_rollover<G, ID, T>(generator: &G, shared_time: SharedMockStepTime)
+fn run_generator_handles_rollover<G, ID, T>(generator: &G, shared_time: &SharedMockStepTime)
 where
     G: SnowflakeGenerator<ID, T>,
     ID: Snowflake,
@@ -136,6 +136,7 @@ where
 {
     let mut last_timestamp = ID::ZERO;
     let mut sequence = ID::ZERO;
+    #[allow(clippy::items_after_statements)]
     const TOTAL_IDS: usize = 4096 * 256;
 
     for _ in 0..TOTAL_IDS {
@@ -271,7 +272,7 @@ fn basic_generator_rollover_test() {
     };
     let generator: BasicSnowflakeGenerator<SnowflakeTwitterId, _> =
         BasicSnowflakeGenerator::new(1, shared_time.clone());
-    run_generator_handles_rollover(&generator, shared_time);
+    run_generator_handles_rollover(&generator, &shared_time);
 }
 
 #[test]
@@ -284,7 +285,7 @@ fn lock_generator_rollover_test() {
     };
     let generator: LockSnowflakeGenerator<SnowflakeTwitterId, _> =
         LockSnowflakeGenerator::new(1, shared_time.clone());
-    run_generator_handles_rollover(&generator, shared_time);
+    run_generator_handles_rollover(&generator, &shared_time);
 }
 
 #[test]
@@ -297,7 +298,7 @@ fn atomic_generator_rollover_test() {
     };
     let generator: AtomicSnowflakeGenerator<SnowflakeTwitterId, _> =
         AtomicSnowflakeGenerator::new(1, shared_time.clone());
-    run_generator_handles_rollover(&generator, shared_time);
+    run_generator_handles_rollover(&generator, &shared_time);
 }
 
 #[test]

--- a/crates/ferroid/src/generator/snowflake/tests.rs
+++ b/crates/ferroid/src/generator/snowflake/tests.rs
@@ -1,6 +1,6 @@
 use crate::{
     AtomicSnowflakeGenerator, BasicSnowflakeGenerator, Id, IdGenStatus, LockSnowflakeGenerator,
-    MonotonicClock, Snowflake, SnowflakeGenerator, SnowflakeTwitterId, TimeSource, ToU64,
+    MonotonicClock, SnowflakeGenerator, SnowflakeId, SnowflakeTwitterId, TimeSource, ToU64,
 };
 use alloc::rc::Rc;
 use alloc::sync::Arc;
@@ -80,7 +80,7 @@ where
 fn run_id_sequence_increments_within_same_tick<G, ID, T>(generator: &G)
 where
     G: SnowflakeGenerator<ID, T>,
-    ID: Snowflake,
+    ID: SnowflakeId,
     T: TimeSource<ID::Ty>,
 {
     let id1 = generator.next_id().unwrap_ready();
@@ -99,7 +99,7 @@ where
 fn run_generator_returns_pending_when_sequence_exhausted<G, ID, T>(generator: &G)
 where
     G: SnowflakeGenerator<ID, T>,
-    ID: Snowflake,
+    ID: SnowflakeId,
     T: TimeSource<ID::Ty>,
 {
     let yield_for = generator.next_id().unwrap_pending();
@@ -109,7 +109,7 @@ where
 fn run_generator_handles_rollover<G, ID, T>(generator: &G, shared_time: &SharedMockStepTime)
 where
     G: SnowflakeGenerator<ID, T>,
-    ID: Snowflake,
+    ID: SnowflakeId,
     T: TimeSource<ID::Ty>,
 {
     for i in 0..=ID::max_sequence().to_u64() {
@@ -131,7 +131,7 @@ where
 fn run_generator_monotonic<G, ID, T>(generator: &G)
 where
     G: SnowflakeGenerator<ID, T>,
-    ID: Snowflake,
+    ID: SnowflakeId,
     T: TimeSource<ID::Ty>,
 {
     let mut last_timestamp = ID::ZERO;
@@ -167,7 +167,7 @@ where
 fn run_generator_monotonic_threaded<G, ID, T>(make_generator: impl Fn() -> G)
 where
     G: SnowflakeGenerator<ID, T> + Send + Sync,
-    ID: Snowflake + Send,
+    ID: SnowflakeId + Send,
     T: TimeSource<ID::Ty>,
 {
     const THREADS: usize = 8;

--- a/crates/ferroid/src/generator/ulid/basic.rs
+++ b/crates/ferroid/src/generator/ulid/basic.rs
@@ -139,6 +139,10 @@ where
     ///   Snowflake API
     /// - Err(e) if the time source or rand source failed
     ///
+    /// # Errors
+    /// - This method currently does not return any errors and always returns
+    ///   `Ok`. It is marked as fallible to allow for future extensibility
+    ///
     /// # Example
     /// ```
     /// use ferroid::{BasicUlidGenerator, IdGenStatus, ULID, MonotonicClock, ThreadRandom};

--- a/crates/ferroid/src/generator/ulid/basic.rs
+++ b/crates/ferroid/src/generator/ulid/basic.rs
@@ -202,6 +202,8 @@ where
     T: TimeSource<ID::Ty>,
     R: RandSource<ID::Ty>,
 {
+    type Err = core::convert::Infallible;
+
     fn new(clock: T, rng: R) -> Self {
         Self::new(clock, rng)
     }
@@ -210,7 +212,7 @@ where
         self.next_id()
     }
 
-    fn try_next_id(&self) -> Result<IdGenStatus<ID>> {
+    fn try_next_id(&self) -> Result<IdGenStatus<ID>, Self::Err> {
         self.try_next_id()
     }
 }

--- a/crates/ferroid/src/generator/ulid/basic.rs
+++ b/crates/ferroid/src/generator/ulid/basic.rs
@@ -68,7 +68,7 @@ where
     ///
     /// [`TimeSource`]: crate::TimeSource
     /// [`RandSource`]: crate::RandSource
-    pub fn new(clock: T, rng: R) -> Self {
+    pub const fn new(clock: T, rng: R) -> Self {
         Self {
             clock,
             rng,

--- a/crates/ferroid/src/generator/ulid/basic.rs
+++ b/crates/ferroid/src/generator/ulid/basic.rs
@@ -54,11 +54,14 @@ where
     ///
     /// # Example
     /// ```
-    /// use ferroid::{BasicUlidGenerator, ULID, MonotonicClock, ThreadRandom};
+    /// #[cfg(all(feature = "std", feature = "alloc", feature = "ulid"))]
+    /// {
+    ///     use ferroid::{BasicUlidGenerator, ULID, MonotonicClock, ThreadRandom};
     ///
-    /// let generator = BasicUlidGenerator::<ULID, _, _>::new(MonotonicClock::default(), ThreadRandom::default());
-    /// let id = generator.next_id();
-    /// println!("Generated ID: {:?}", id);
+    ///     let generator = BasicUlidGenerator::<ULID, _, _>::new(MonotonicClock::default(), ThreadRandom::default());
+    ///     let id = generator.next_id();
+    ///     println!("Generated ID: {:?}", id);
+    /// }
     /// ```
     ///
     /// [`TimeSource`]: crate::TimeSource
@@ -108,19 +111,22 @@ where
     ///
     /// # Example
     /// ```
-    /// use ferroid::{BasicUlidGenerator, IdGenStatus, ULID, MonotonicClock, ThreadRandom};
+    /// #[cfg(all(feature = "std", feature = "alloc", feature = "ulid"))]
+    /// {
+    ///     use ferroid::{BasicUlidGenerator, IdGenStatus, ULID, MonotonicClock, ThreadRandom};
     ///
-    /// let clock = MonotonicClock::default();
-    /// let rand = ThreadRandom::default();
-    /// let generator = BasicUlidGenerator::<ULID, _, _>::new(clock, rand);
+    ///     let clock = MonotonicClock::default();
+    ///     let rand = ThreadRandom::default();
+    ///     let generator = BasicUlidGenerator::<ULID, _, _>::new(clock, rand);
     ///
-    /// // Attempt to generate a new ID
-    /// match generator.next_id() {
-    ///     IdGenStatus::Ready { id } => {
-    ///         println!("ID: {}", id);
-    ///     }
-    ///     IdGenStatus::Pending { yield_for } => {
-    ///         println!("Exhausted; wait for: {}ms", yield_for);
+    ///     // Attempt to generate a new ID
+    ///     match generator.next_id() {
+    ///         IdGenStatus::Ready { id } => {
+    ///             println!("ID: {}", id);
+    ///         }
+    ///         IdGenStatus::Pending { yield_for } => {
+    ///             println!("Exhausted; wait for: {}ms", yield_for);
+    ///         }
     ///     }
     /// }
     /// ```
@@ -145,21 +151,24 @@ where
     ///
     /// # Example
     /// ```
-    /// use ferroid::{BasicUlidGenerator, IdGenStatus, ULID, MonotonicClock, ThreadRandom};
+    /// #[cfg(all(feature = "std", feature = "alloc", feature = "ulid"))]
+    /// {
+    ///     use ferroid::{BasicUlidGenerator, IdGenStatus, ULID, MonotonicClock, ThreadRandom};
     ///
-    /// let clock = MonotonicClock::default();
-    /// let rand = ThreadRandom::default();
-    /// let generator = BasicUlidGenerator::<ULID, _, _>::new(clock, rand);
+    ///     let clock = MonotonicClock::default();
+    ///     let rand = ThreadRandom::default();
+    ///     let generator = BasicUlidGenerator::<ULID, _, _>::new(clock, rand);
     ///
-    /// // Attempt to generate a new ID
-    /// match generator.try_next_id() {
-    ///     Ok(IdGenStatus::Ready { id }) => {
-    ///         println!("ID: {}", id);
+    ///     // Attempt to generate a new ID
+    ///     match generator.try_next_id() {
+    ///         Ok(IdGenStatus::Ready { id }) => {
+    ///             println!("ID: {}", id);
+    ///         }
+    ///         Ok(IdGenStatus::Pending { yield_for }) => {
+    ///             println!("Exhausted; wait for: {}ms", yield_for);
+    ///         }
+    ///         Err(e) => eprintln!("Generator error: {}", e),
     ///     }
-    ///     Ok(IdGenStatus::Pending { yield_for }) => {
-    ///         println!("Exhausted; wait for: {}ms", yield_for);
-    ///     }
-    ///     Err(e) => eprintln!("Generator error: {}", e),
     /// }
     /// ```
     #[cfg_attr(feature = "tracing", instrument(level = "trace", skip(self)))]

--- a/crates/ferroid/src/generator/ulid/basic_mono.rs
+++ b/crates/ferroid/src/generator/ulid/basic_mono.rs
@@ -1,49 +1,49 @@
 use crate::{IdGenStatus, Result, TimeSource, UlidGenerator, UlidId, rand::RandSource};
-use core::marker::PhantomData;
+use core::{cell::Cell, cmp::Ordering};
 #[cfg(feature = "tracing")]
 use tracing::instrument;
 
-/// A *non-monotonic* ULID-style ID generator suitable for multi-threaded
+/// A *monotonic* ULID-style ID generator suitable for single-threaded
 /// environments.
 ///
-/// This generator is lightweight and fast, but has a higher collision
-/// probabiliy than it's monotonic counterpart.
+/// This generator is lightweight and fast, but is not thread-safe.
 ///
 /// ## Features
 ///
-/// - ✅ Thread-safe
+/// - ❌ Not thread-safe
 /// - ✅ Probabilistically unique (no coordination required)
-/// - ✅ Time-ordered (not monotonically increasing, random per millisecond)
+/// - ✅ Time-ordered (monotonically increasing per millisecond)
 ///
 /// ## Recommended When
 ///
-/// - You're in a single or multi-threaded environment
-/// - You require purely random IDs (even within the same millisecond)
+/// - You're in a single-threaded environment (no shared access)
+/// - You need require monotonically increasing IDs (ID generated within the
+///   same millisecond increment a sequence counter)
 ///
 /// ## See Also
-/// - [`BasicMonoUlidGenerator`]
+/// - [`BasicUlidGenerator`]
 /// - [`LockMonoUlidGenerator`]
 ///
-/// [`BasicMonoUlidGenerator`]: crate::BasicMonoUlidGenerator
+/// [`BasicUlidGenerator`]: crate::BasicUlidGenerator
 /// [`LockMonoUlidGenerator`]: crate::LockMonoUlidGenerator
-pub struct BasicUlidGenerator<ID, T, R>
+pub struct BasicMonoUlidGenerator<ID, T, R>
 where
     ID: UlidId,
     T: TimeSource<ID::Ty>,
     R: RandSource<ID::Ty>,
 {
+    state: Cell<ID>,
     clock: T,
     rng: R,
-    _id: PhantomData<ID>,
 }
 
-impl<ID, T, R> BasicUlidGenerator<ID, T, R>
+impl<ID, T, R> BasicMonoUlidGenerator<ID, T, R>
 where
     ID: UlidId,
     T: TimeSource<ID::Ty>,
     R: RandSource<ID::Ty>,
 {
-    /// Creates a new [`BasicUlidGenerator`] with the provided time source and
+    /// Creates a new [`BasicMonoUlidGenerator`] with the provided time source and
     /// RNG.
     ///
     /// # Parameters
@@ -58,9 +58,9 @@ where
     /// ```
     /// #[cfg(all(feature = "std", feature = "alloc", feature = "ulid"))]
     /// {
-    ///     use ferroid::{BasicUlidGenerator, ULID, MonotonicClock, ThreadRandom};
+    ///     use ferroid::{BasicMonoUlidGenerator, ULID, MonotonicClock, ThreadRandom};
     ///
-    ///     let generator = BasicUlidGenerator::<ULID, _, _>::new(MonotonicClock::default(), ThreadRandom::default());
+    ///     let generator = BasicMonoUlidGenerator::<ULID, _, _>::new(MonotonicClock::default(), ThreadRandom::default());
     ///     let id = generator.next_id();
     ///     println!("Generated ID: {:?}", id);
     /// }
@@ -69,10 +69,34 @@ where
     /// [`TimeSource`]: crate::TimeSource
     /// [`RandSource`]: crate::RandSource
     pub fn new(clock: T, rng: R) -> Self {
+        Self::from_components(ID::ZERO, ID::ZERO, clock, rng)
+    }
+
+    /// Creates a new ID generator from explicit component values.
+    ///
+    /// This constructor is primarily useful for advanced use cases such as
+    /// restoring state from persistent storage or controlling the starting
+    /// point of the generator manually.
+    ///
+    /// # Parameters
+    /// - `timestamp`: The initial timestamp component (usually in milliseconds)
+    /// - `machine_id`: The machine or worker identifier
+    /// - `sequence`: The initial sequence number
+    /// - `clock`: A [`TimeSource`] implementation used to fetch the current
+    ///   time
+    ///
+    /// # Returns
+    /// A new generator instance preloaded with the given state.
+    ///
+    /// # ⚠️ Note
+    /// In typical use cases, you should prefer [`Self::new`] to let the
+    /// generator initialize itself from the current time.
+    pub fn from_components(timestamp: ID::Ty, random: ID::Ty, clock: T, rng: R) -> Self {
+        let id = ID::from_components(timestamp, random);
         Self {
+            state: Cell::new(id),
             clock,
             rng,
-            _id: PhantomData,
         }
     }
 
@@ -91,11 +115,11 @@ where
     /// ```
     /// #[cfg(all(feature = "std", feature = "alloc", feature = "ulid"))]
     /// {
-    ///     use ferroid::{BasicUlidGenerator, IdGenStatus, ULID, MonotonicClock, ThreadRandom};
+    ///     use ferroid::{BasicMonoUlidGenerator, IdGenStatus, ULID, MonotonicClock, ThreadRandom};
     ///
     ///     let clock = MonotonicClock::default();
     ///     let rand = ThreadRandom::default();
-    ///     let generator = BasicUlidGenerator::<ULID, _, _>::new(clock, rand);
+    ///     let generator = BasicMonoUlidGenerator::<ULID, _, _>::new(clock, rand);
     ///
     ///     // Attempt to generate a new ID
     ///     match generator.next_id() {
@@ -131,11 +155,11 @@ where
     /// ```
     /// #[cfg(all(feature = "std", feature = "alloc", feature = "ulid"))]
     /// {
-    ///     use ferroid::{BasicUlidGenerator, IdGenStatus, ULID, MonotonicClock, ThreadRandom};
+    ///     use ferroid::{BasicMonoUlidGenerator, IdGenStatus, ULID, MonotonicClock, ThreadRandom};
     ///
     ///     let clock = MonotonicClock::default();
     ///     let rand = ThreadRandom::default();
-    ///     let generator = BasicUlidGenerator::<ULID, _, _>::new(clock, rand);
+    ///     let generator = BasicMonoUlidGenerator::<ULID, _, _>::new(clock, rand);
     ///
     ///     // Attempt to generate a new ID
     ///     match generator.try_next_id() {
@@ -151,13 +175,39 @@ where
     /// ```
     #[cfg_attr(feature = "tracing", instrument(level = "trace", skip(self)))]
     pub fn try_next_id(&self) -> Result<IdGenStatus<ID>> {
-        Ok(IdGenStatus::Ready {
-            id: ID::from_components(self.clock.current_millis(), self.rng.rand()),
-        })
+        let now = self.clock.current_millis();
+        let state = self.state.get();
+        let current_ts = state.timestamp();
+
+        let status = match now.cmp(&current_ts) {
+            Ordering::Less => {
+                let yield_for = current_ts - now;
+                debug_assert!(yield_for >= ID::ZERO);
+                IdGenStatus::Pending { yield_for }
+            }
+            Ordering::Greater => {
+                // Set the new timestamp and random number.
+                let rand = self.rng.rand();
+                let updated = state.rollover_to_timestamp(now, rand);
+                self.state.set(updated);
+                IdGenStatus::Ready { id: updated }
+            }
+            Ordering::Equal => {
+                if state.has_random_room() {
+                    let updated = state.increment_random();
+                    self.state.set(updated);
+                    IdGenStatus::Ready { id: updated }
+                } else {
+                    IdGenStatus::Pending { yield_for: ID::ONE }
+                }
+            }
+        };
+
+        Ok(status)
     }
 }
 
-impl<ID, T, R> UlidGenerator<ID, T, R> for BasicUlidGenerator<ID, T, R>
+impl<ID, T, R> UlidGenerator<ID, T, R> for BasicMonoUlidGenerator<ID, T, R>
 where
     ID: UlidId,
     T: TimeSource<ID::Ty>,

--- a/crates/ferroid/src/generator/ulid/interface.rs
+++ b/crates/ferroid/src/generator/ulid/interface.rs
@@ -14,5 +14,9 @@ where
     fn next_id(&self) -> IdGenStatus<ID>;
 
     /// A fallible version of [`Self::next_id`] that returns a [`Result`].
+    ///
+    /// # Errors
+    /// - May return an error if the underlying generator uses a lock and it is
+    ///   poisoned.
     fn try_next_id(&self) -> Result<IdGenStatus<ID>>;
 }

--- a/crates/ferroid/src/generator/ulid/interface.rs
+++ b/crates/ferroid/src/generator/ulid/interface.rs
@@ -1,4 +1,5 @@
 use crate::{IdGenStatus, RandSource, Result, TimeSource, Ulid};
+use core::fmt;
 
 /// A minimal interface for generating Ulid IDs
 pub trait UlidGenerator<ID, T, R>
@@ -7,6 +8,8 @@ where
     T: TimeSource<ID::Ty>,
     R: RandSource<ID::Ty>,
 {
+    type Err: fmt::Debug;
+
     // Creates a new generator
     fn new(clock: T, rng: R) -> Self;
 
@@ -18,5 +21,5 @@ where
     /// # Errors
     /// - May return an error if the underlying generator uses a lock and it is
     ///   poisoned.
-    fn try_next_id(&self) -> Result<IdGenStatus<ID>>;
+    fn try_next_id(&self) -> Result<IdGenStatus<ID>, Self::Err>;
 }

--- a/crates/ferroid/src/generator/ulid/interface.rs
+++ b/crates/ferroid/src/generator/ulid/interface.rs
@@ -1,10 +1,10 @@
-use crate::{IdGenStatus, RandSource, Result, TimeSource, Ulid};
+use crate::{IdGenStatus, RandSource, Result, TimeSource, UlidId};
 use core::fmt;
 
 /// A minimal interface for generating Ulid IDs
 pub trait UlidGenerator<ID, T, R>
 where
-    ID: Ulid,
+    ID: UlidId,
     T: TimeSource<ID::Ty>,
     R: RandSource<ID::Ty>,
 {

--- a/crates/ferroid/src/generator/ulid/lock.rs
+++ b/crates/ferroid/src/generator/ulid/lock.rs
@@ -56,11 +56,14 @@ where
     ///
     /// # Example
     /// ```
-    /// use ferroid::{LockUlidGenerator, ULID, MonotonicClock, ThreadRandom};
+    /// #[cfg(all(feature = "std", feature = "ulid"))]
+    /// {
+    ///     use ferroid::{LockUlidGenerator, ULID, MonotonicClock, ThreadRandom};
     ///
-    /// let generator = LockUlidGenerator::<ULID, _, _>::new(MonotonicClock::default(), ThreadRandom::default());
-    /// let id = generator.next_id();
-    /// println!("Generated ID: {:?}", id);
+    ///     let generator = LockUlidGenerator::<ULID, _, _>::new(MonotonicClock::default(), ThreadRandom::default());
+    ///     let id = generator.next_id();
+    ///     println!("Generated ID: {:?}", id);
+    /// }
     /// ```
     ///
     /// [`TimeSource`]: crate::TimeSource
@@ -109,19 +112,22 @@ where
     ///
     /// # Example
     /// ```
-    /// use ferroid::{LockUlidGenerator, IdGenStatus, ULID, MonotonicClock, ThreadRandom};
+    /// #[cfg(all(feature = "std", feature = "ulid"))]
+    /// {
+    ///     use ferroid::{LockUlidGenerator, IdGenStatus, ULID, MonotonicClock, ThreadRandom};
     ///
-    /// let clock = MonotonicClock::default();
-    /// let rand = ThreadRandom::default();
-    /// let generator = LockUlidGenerator::<ULID, _, _>::new(clock, rand);
+    ///     let clock = MonotonicClock::default();
+    ///     let rand = ThreadRandom::default();
+    ///     let generator = LockUlidGenerator::<ULID, _, _>::new(clock, rand);
     ///
-    /// // Attempt to generate a new ID
-    /// match generator.next_id() {
-    ///     IdGenStatus::Ready { id } => {
-    ///         println!("ID: {}", id);
-    ///     }
-    ///     IdGenStatus::Pending { yield_for } => {
-    ///         println!("Exhausted; wait for: {}ms", yield_for);
+    ///     // Attempt to generate a new ID
+    ///     match generator.next_id() {
+    ///         IdGenStatus::Ready { id } => {
+    ///             println!("ID: {}", id);
+    ///         }
+    ///         IdGenStatus::Pending { yield_for } => {
+    ///             println!("Exhausted; wait for: {}ms", yield_for);
+    ///         }
     ///     }
     /// }
     /// ```
@@ -145,23 +151,26 @@ where
     ///
     /// # Example
     /// ```
-    /// use ferroid::{LockUlidGenerator, IdGenStatus, ULID, MonotonicClock, ThreadRandom};
+    /// #[cfg(all(feature = "std", feature = "ulid"))]
+    /// {
+    ///     use ferroid::{LockUlidGenerator, IdGenStatus, ULID, MonotonicClock, ThreadRandom};
     ///
-    /// let clock = MonotonicClock::default();
-    /// let rand = ThreadRandom::default();
-    /// let generator = LockUlidGenerator::<ULID, _, _>::new(clock, rand);
+    ///     let clock = MonotonicClock::default();
+    ///     let rand = ThreadRandom::default();
+    ///     let generator = LockUlidGenerator::<ULID, _, _>::new(clock, rand);
     ///
-    /// // Attempt to generate a new ID
-    /// match generator.try_next_id() {
-    ///     Ok(IdGenStatus::Ready { id }) => {
-    ///         println!("ID: {}", id);
+    ///     // Attempt to generate a new ID
+    ///     match generator.try_next_id() {
+    ///         Ok(IdGenStatus::Ready { id }) => {
+    ///             println!("ID: {}", id);
+    ///         }
+    ///         Ok(IdGenStatus::Pending { yield_for }) => {
+    ///             // In practice, Ulid generators will never return `Pending`, but
+    ///             // it is kept to have a consistent API.
+    ///             println!("Exhausted; wait for: {}ms", yield_for);
+    ///         }
+    ///         Err(e) => eprintln!("Generator error: {}", e),
     ///     }
-    ///     Ok(IdGenStatus::Pending { yield_for }) => {
-    ///         // In practice, Ulid generators will never return `Pending`, but
-    ///         // it is kept to have a consistent API.
-    ///         println!("Exhausted; wait for: {}ms", yield_for);
-    ///     }
-    ///     Err(e) => eprintln!("Generator error: {}", e),
     /// }
     /// ```
     #[cfg_attr(feature = "tracing", instrument(level = "trace", skip(self)))]

--- a/crates/ferroid/src/generator/ulid/lock.rs
+++ b/crates/ferroid/src/generator/ulid/lock.rs
@@ -140,6 +140,9 @@ where
     ///   Snowflake API
     /// - Err(e) if the time source or rand source failed
     ///
+    /// # Errors
+    /// - Returns an error if the underlying lock has been poisoned.
+    ///
     /// # Example
     /// ```
     /// use ferroid::{LockUlidGenerator, IdGenStatus, ULID, MonotonicClock, ThreadRandom};

--- a/crates/ferroid/src/generator/ulid/lock.rs
+++ b/crates/ferroid/src/generator/ulid/lock.rs
@@ -1,4 +1,4 @@
-use crate::{IdGenStatus, Result, TimeSource, Ulid, UlidGenerator, rand::RandSource};
+use crate::{Error, IdGenStatus, Result, TimeSource, Ulid, UlidGenerator, rand::RandSource};
 use core::cmp::Ordering;
 use std::sync::{Arc, Mutex};
 #[cfg(feature = "tracing")]
@@ -165,7 +165,7 @@ where
     /// }
     /// ```
     #[cfg_attr(feature = "tracing", instrument(level = "trace", skip(self)))]
-    pub fn try_next_id(&self) -> Result<IdGenStatus<ID>> {
+    pub fn try_next_id(&self) -> Result<IdGenStatus<ID>, Error<core::convert::Infallible>> {
         let now = self.clock.current_millis();
         let mut id = self.state.lock()?;
         let current_ts = id.timestamp();
@@ -201,6 +201,8 @@ where
     T: TimeSource<ID::Ty>,
     R: RandSource<ID::Ty>,
 {
+    type Err = Error;
+
     fn new(clock: T, rng: R) -> Self {
         Self::new(clock, rng)
     }
@@ -209,7 +211,7 @@ where
         self.next_id()
     }
 
-    fn try_next_id(&self) -> Result<IdGenStatus<ID>> {
+    fn try_next_id(&self) -> Result<IdGenStatus<ID>, Self::Err> {
         self.try_next_id()
     }
 }

--- a/crates/ferroid/src/generator/ulid/lock_mono.rs
+++ b/crates/ferroid/src/generator/ulid/lock_mono.rs
@@ -1,4 +1,4 @@
-use crate::{Error, IdGenStatus, Result, TimeSource, Ulid, UlidGenerator, rand::RandSource};
+use crate::{Error, IdGenStatus, Result, TimeSource, UlidGenerator, UlidId, rand::RandSource};
 use core::cmp::Ordering;
 use std::sync::{Arc, Mutex};
 #[cfg(feature = "tracing")]
@@ -24,11 +24,13 @@ use tracing::instrument;
 ///
 /// ## See Also
 /// - [`BasicUlidGenerator`]
+/// - [`BasicMonoUlidGenerator`]
 ///
 /// [`BasicUlidGenerator`]: crate::BasicUlidGenerator
-pub struct LockUlidGenerator<ID, T, R>
+/// [`BasicMonoUlidGenerator`]: crate::BasicMonoUlidGenerator
+pub struct LockMonoUlidGenerator<ID, T, R>
 where
-    ID: Ulid,
+    ID: UlidId,
     T: TimeSource<ID::Ty>,
     R: RandSource<ID::Ty>,
 {
@@ -37,13 +39,13 @@ where
     rng: R,
 }
 
-impl<ID, T, R> LockUlidGenerator<ID, T, R>
+impl<ID, T, R> LockMonoUlidGenerator<ID, T, R>
 where
-    ID: Ulid,
+    ID: UlidId,
     T: TimeSource<ID::Ty>,
     R: RandSource<ID::Ty>,
 {
-    /// Creates a new [`LockUlidGenerator`] with the provided time source and
+    /// Creates a new [`LockMonoUlidGenerator`] with the provided time source and
     /// RNG.
     ///
     /// # Parameters
@@ -58,9 +60,9 @@ where
     /// ```
     /// #[cfg(all(feature = "std", feature = "ulid"))]
     /// {
-    ///     use ferroid::{LockUlidGenerator, ULID, MonotonicClock, ThreadRandom};
+    ///     use ferroid::{LockMonoUlidGenerator, ULID, MonotonicClock, ThreadRandom};
     ///
-    ///     let generator = LockUlidGenerator::<ULID, _, _>::new(MonotonicClock::default(), ThreadRandom::default());
+    ///     let generator = LockMonoUlidGenerator::<ULID, _, _>::new(MonotonicClock::default(), ThreadRandom::default());
     ///     let id = generator.next_id();
     ///     println!("Generated ID: {:?}", id);
     /// }
@@ -114,11 +116,11 @@ where
     /// ```
     /// #[cfg(all(feature = "std", feature = "ulid"))]
     /// {
-    ///     use ferroid::{LockUlidGenerator, IdGenStatus, ULID, MonotonicClock, ThreadRandom};
+    ///     use ferroid::{LockMonoUlidGenerator, IdGenStatus, ULID, MonotonicClock, ThreadRandom};
     ///
     ///     let clock = MonotonicClock::default();
     ///     let rand = ThreadRandom::default();
-    ///     let generator = LockUlidGenerator::<ULID, _, _>::new(clock, rand);
+    ///     let generator = LockMonoUlidGenerator::<ULID, _, _>::new(clock, rand);
     ///
     ///     // Attempt to generate a new ID
     ///     match generator.next_id() {
@@ -153,11 +155,11 @@ where
     /// ```
     /// #[cfg(all(feature = "std", feature = "ulid"))]
     /// {
-    ///     use ferroid::{LockUlidGenerator, IdGenStatus, ULID, MonotonicClock, ThreadRandom};
+    ///     use ferroid::{LockMonoUlidGenerator, IdGenStatus, ULID, MonotonicClock, ThreadRandom};
     ///
     ///     let clock = MonotonicClock::default();
     ///     let rand = ThreadRandom::default();
-    ///     let generator = LockUlidGenerator::<ULID, _, _>::new(clock, rand);
+    ///     let generator = LockMonoUlidGenerator::<ULID, _, _>::new(clock, rand);
     ///
     ///     // Attempt to generate a new ID
     ///     match generator.try_next_id() {
@@ -204,9 +206,9 @@ where
     }
 }
 
-impl<ID, T, R> UlidGenerator<ID, T, R> for LockUlidGenerator<ID, T, R>
+impl<ID, T, R> UlidGenerator<ID, T, R> for LockMonoUlidGenerator<ID, T, R>
 where
-    ID: Ulid,
+    ID: UlidId,
     T: TimeSource<ID::Ty>,
     R: RandSource<ID::Ty>,
 {

--- a/crates/ferroid/src/generator/ulid/mod.rs
+++ b/crates/ferroid/src/generator/ulid/mod.rs
@@ -1,15 +1,18 @@
 mod basic;
+mod basic_mono;
 mod interface;
+
 #[cfg(all(feature = "std", feature = "alloc"))]
-mod lock;
+mod lock_mono;
 #[cfg(all(test, feature = "std", feature = "alloc"))]
 mod tests;
 #[cfg(feature = "thread_local")]
 mod thread_local;
 
 pub use basic::*;
+pub use basic_mono::*;
 pub use interface::*;
 #[cfg(all(feature = "std", feature = "alloc"))]
-pub use lock::*;
+pub use lock_mono::*;
 #[cfg(feature = "thread_local")]
 pub use thread_local::*;

--- a/crates/ferroid/src/generator/ulid/mod.rs
+++ b/crates/ferroid/src/generator/ulid/mod.rs
@@ -2,7 +2,7 @@ mod basic;
 mod interface;
 #[cfg(all(feature = "std", feature = "alloc"))]
 mod lock;
-#[cfg(test)]
+#[cfg(all(test, feature = "std", feature = "alloc"))]
 mod tests;
 #[cfg(feature = "thread_local")]
 mod thread_local;

--- a/crates/ferroid/src/generator/ulid/mod.rs
+++ b/crates/ferroid/src/generator/ulid/mod.rs
@@ -1,11 +1,15 @@
 mod basic;
 mod interface;
+#[cfg(all(feature = "std", feature = "alloc"))]
 mod lock;
 #[cfg(test)]
 mod tests;
+#[cfg(feature = "thread_local")]
 mod thread_local;
 
 pub use basic::*;
 pub use interface::*;
+#[cfg(all(feature = "std", feature = "alloc"))]
 pub use lock::*;
+#[cfg(feature = "thread_local")]
 pub use thread_local::*;

--- a/crates/ferroid/src/generator/ulid/tests.rs
+++ b/crates/ferroid/src/generator/ulid/tests.rs
@@ -47,7 +47,7 @@ impl SharedMockStepTime {
 
 impl TimeSource<u128> for SharedMockStepTime {
     fn current_millis(&self) -> u128 {
-        self.clock.values[self.clock.index.get()] as u128
+        u128::from(self.clock.values[self.clock.index.get()])
     }
 }
 struct MockStepTime {
@@ -90,8 +90,8 @@ where
 {
     fn unwrap_ready(self) -> T {
         match self {
-            IdGenStatus::Ready { id } => id,
-            IdGenStatus::Pending { yield_for } => {
+            Self::Ready { id } => id,
+            Self::Pending { yield_for } => {
                 panic!("unexpected pending (yield for: {yield_for})")
             }
         }
@@ -99,8 +99,8 @@ where
 
     fn unwrap_pending(self) -> T::Ty {
         match self {
-            IdGenStatus::Ready { id } => panic!("unexpected ready ({id})"),
-            IdGenStatus::Pending { yield_for } => yield_for,
+            Self::Ready { id } => panic!("unexpected ready ({id})"),
+            Self::Pending { yield_for } => yield_for,
         }
     }
 }
@@ -214,8 +214,7 @@ where
                     loop {
                         match generator.next_id() {
                             IdGenStatus::Ready { id } => {
-                                let mut set = seen_ids.lock().unwrap();
-                                assert!(set.insert(id));
+                                assert!(seen_ids.lock().unwrap().insert(id));
                                 break;
                             }
                             IdGenStatus::Pending { .. } => std::thread::yield_now(),

--- a/crates/ferroid/src/generator/ulid/tests.rs
+++ b/crates/ferroid/src/generator/ulid/tests.rs
@@ -2,10 +2,12 @@ use crate::{
     BasicUlidGenerator, Id, IdGenStatus, LockUlidGenerator, MonotonicClock, RandSource,
     ThreadRandom, TimeSource, ToU64, ULID, Ulid, UlidGenerator,
 };
+use alloc::rc::Rc;
+use alloc::sync::Arc;
+use alloc::{vec, vec::Vec};
 use core::cell::Cell;
 use std::collections::HashSet;
-use std::rc::Rc;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 use std::thread::scope;
 
 struct MockTime {

--- a/crates/ferroid/src/generator/ulid/tests.rs
+++ b/crates/ferroid/src/generator/ulid/tests.rs
@@ -164,6 +164,7 @@ where
 {
     let mut last_timestamp = ID::ZERO;
     let mut random = None;
+    #[allow(clippy::items_after_statements)]
     const TOTAL_IDS: usize = 4096 * 256;
 
     for _ in 0..TOTAL_IDS {

--- a/crates/ferroid/src/generator/ulid/tests.rs
+++ b/crates/ferroid/src/generator/ulid/tests.rs
@@ -105,7 +105,7 @@ where
     }
 }
 
-fn run_id_sequence_increments_within_same_tick<G, ID, T, R>(generator: G)
+fn run_id_sequence_increments_within_same_tick<G, ID, T, R>(generator: &G)
 where
     G: UlidGenerator<ID, T, R>,
     ID: Ulid,
@@ -125,7 +125,7 @@ where
     assert!(id1 < id2 && id2 < id3);
 }
 
-fn run_generator_returns_pending_when_sequence_exhausted<G, ID, T, R>(generator: G)
+fn run_generator_returns_pending_when_sequence_exhausted<G, ID, T, R>(generator: &G)
 where
     G: UlidGenerator<ID, T, R>,
     ID: Ulid,
@@ -136,7 +136,7 @@ where
     assert_eq!(yield_for, ID::ONE);
 }
 
-fn run_generator_handles_rollover<G, ID, T, R>(generator: G, shared_time: SharedMockStepTime)
+fn run_generator_handles_rollover<G, ID, T, R>(generator: &G, shared_time: &SharedMockStepTime)
 where
     G: UlidGenerator<ID, T, R>,
     ID: Ulid,
@@ -155,7 +155,7 @@ where
     assert_eq!(id.timestamp().to_u64(), 43);
 }
 
-fn run_generator_monotonic<G, ID, T, R>(generator: G)
+fn run_generator_monotonic<G, ID, T, R>(generator: &G)
 where
     G: UlidGenerator<ID, T, R>,
     ID: Ulid,
@@ -234,7 +234,7 @@ fn basic_generator_sequence_test() {
     let mock_time = MockTime { millis: 42 };
     let mock_rand = MockRand { rand: 42 };
     let generator: BasicUlidGenerator<ULID, _, _> = BasicUlidGenerator::new(mock_time, mock_rand);
-    run_id_sequence_increments_within_same_tick(generator);
+    run_id_sequence_increments_within_same_tick(&generator);
 }
 
 #[test]
@@ -243,21 +243,21 @@ fn lock_generator_sequence_test() {
     let mock_rand = MockRand { rand: 42 };
 
     let generator: LockUlidGenerator<ULID, _, _> = LockUlidGenerator::new(mock_time, mock_rand);
-    run_id_sequence_increments_within_same_tick(generator);
+    run_id_sequence_increments_within_same_tick(&generator);
 }
 
 #[test]
 fn basic_generator_pending_test() {
     let generator: BasicUlidGenerator<ULID, _, _> =
         BasicUlidGenerator::from_components(0, ULID::max_random(), FixedTime, MinRand);
-    run_generator_returns_pending_when_sequence_exhausted(generator);
+    run_generator_returns_pending_when_sequence_exhausted(&generator);
 }
 
 #[test]
 fn lock_generator_pending_test() {
     let generator: LockUlidGenerator<ULID, _, _> =
         LockUlidGenerator::from_components(0, ULID::max_random(), FixedTime, MinRand);
-    run_generator_returns_pending_when_sequence_exhausted(generator);
+    run_generator_returns_pending_when_sequence_exhausted(&generator);
 }
 
 #[test]
@@ -265,7 +265,7 @@ fn basic_generator_rollover_test() {
     let shared_time = SharedMockStepTime::new(vec![42, 43], 0);
     let generator: BasicUlidGenerator<ULID, _, _> =
         BasicUlidGenerator::new(shared_time.clone(), MaxRand);
-    run_generator_handles_rollover(generator, shared_time);
+    run_generator_handles_rollover(&generator, &shared_time);
 }
 
 #[test]
@@ -273,7 +273,7 @@ fn lock_generator_rollover_test() {
     let shared_time = SharedMockStepTime::new(vec![42, 43], 0);
     let generator: LockUlidGenerator<ULID, _, _> =
         LockUlidGenerator::new(shared_time.clone(), MaxRand);
-    run_generator_handles_rollover(generator, shared_time);
+    run_generator_handles_rollover(&generator, &shared_time);
 }
 
 #[test]
@@ -281,7 +281,7 @@ fn basic_generator_monotonic_clock_random_increments() {
     let clock = MonotonicClock::default();
     let rand = ThreadRandom;
     let generator: BasicUlidGenerator<ULID, _, _> = BasicUlidGenerator::new(clock, rand);
-    run_generator_monotonic(generator);
+    run_generator_monotonic(&generator);
 }
 
 #[test]
@@ -289,7 +289,7 @@ fn lock_generator_monotonic_clock_random_increments() {
     let clock = MonotonicClock::default();
     let rand = ThreadRandom;
     let generator: LockUlidGenerator<ULID, _, _> = LockUlidGenerator::new(clock, rand);
-    run_generator_monotonic(generator);
+    run_generator_monotonic(&generator);
 }
 
 #[test]

--- a/crates/ferroid/src/generator/ulid/thread_local.rs
+++ b/crates/ferroid/src/generator/ulid/thread_local.rs
@@ -94,10 +94,10 @@ impl UlidMono {
     /// #[cfg(feature = "ulid")]
     /// {
     ///     use ferroid::UlidMono;
-    ///     let id = UlidMono::new();
+    ///     let id = UlidMono::new_ulid();
     /// }
     /// ```
-    pub fn new() -> ULID {
+    pub fn new_ulid() -> ULID {
         Self::with_backoff(Backoff::Yield)
     }
 

--- a/crates/ferroid/src/generator/ulid/thread_local.rs
+++ b/crates/ferroid/src/generator/ulid/thread_local.rs
@@ -91,7 +91,7 @@ impl UlidMono {
     ///
     /// # Example
     /// ```
-    /// #[cfg(feature = "ulid")]
+    /// #[cfg(all(feature = "ulid", feature = "thread_local"))]
     /// {
     ///     use ferroid::UlidMono;
     ///     let id = UlidMono::new_ulid();
@@ -110,7 +110,7 @@ impl UlidMono {
     ///
     /// # Example
     /// ```
-    /// #[cfg(feature = "ulid")]
+    /// #[cfg(all(feature = "ulid", feature = "thread_local"))]
     /// {
     ///     use ferroid::{UlidMono, Backoff};
     ///     let id = UlidMono::with_backoff(Backoff::Spin);
@@ -128,7 +128,7 @@ impl UlidMono {
     ///
     /// # Example
     /// ```
-    /// #[cfg(feature = "ulid")]
+    /// #[cfg(all(feature = "ulid", feature = "thread_local"))]
     /// {
     ///     use ferroid::UlidMono;
     ///     let id = UlidMono::from_timestamp(1_694_201_234_000);
@@ -146,7 +146,7 @@ impl UlidMono {
     ///
     /// # Example
     /// ```
-    /// #[cfg(feature = "ulid")]
+    /// #[cfg(all(feature = "ulid", feature = "thread_local"))]
     /// {
     ///     use ferroid::{UlidMono, ThreadRandom};
     ///     let id = UlidMono::from_timestamp_and_rand(0, &ThreadRandom);
@@ -166,7 +166,7 @@ impl UlidMono {
     ///
     /// # Example
     /// ```
-    /// #[cfg(feature = "ulid")]
+    /// #[cfg(all(feature = "ulid", feature = "thread_local"))]
     /// {
     ///     use ferroid::UlidMono;
     ///     let id = UlidMono::from_datetime(std::time::SystemTime::now());
@@ -181,7 +181,7 @@ impl UlidMono {
     ///
     /// # Example
     /// ```
-    /// #[cfg(feature = "ulid")]
+    /// #[cfg(all(feature = "ulid", feature = "thread_local"))]
     /// {
     ///     use ferroid::{UlidMono, ThreadRandom};
     ///     let now = std::time::SystemTime::now();

--- a/crates/ferroid/src/generator/ulid/thread_local.rs
+++ b/crates/ferroid/src/generator/ulid/thread_local.rs
@@ -6,12 +6,12 @@
 //! In rare cases where the generator saturates within the same millisecond
 //! (monotonic overflow), it yields using the configured backoff strategy (e.g.,
 //! spin, yield, sleep). These overflows typically resolve within ~1ms.
-
 use crate::{
     BasicUlidGenerator, Id, IdGenStatus, MonotonicClock, RandSource, ThreadRandom, ToU64, ULID,
     UNIX_EPOCH,
 };
 use std::sync::LazyLock;
+use std::thread_local;
 
 /// A global clock returning milliseconds since the Unix epoch, guaranteed to be
 /// strictly monotonic.

--- a/crates/ferroid/src/generator/ulid/thread_local.rs
+++ b/crates/ferroid/src/generator/ulid/thread_local.rs
@@ -24,7 +24,7 @@ thread_local! {
     static BASIC_ULID: BasicUlidGenerator<ULID, MonotonicClock, ThreadRandom> =
         BasicUlidGenerator::new(
             GLOBAL_MONOTONIC_CLOCK.clone(),
-            ThreadRandom,
+            ThreadRandom
         );
 
     /// A thread-local, monotonic ULID generator that reads from a global
@@ -32,7 +32,7 @@ thread_local! {
     static BASIC_MONO_ULID: BasicMonoUlidGenerator<ULID, MonotonicClock, ThreadRandom> =
         BasicMonoUlidGenerator::new(
             GLOBAL_MONOTONIC_CLOCK.clone(),
-            ThreadRandom,
+            ThreadRandom
         );
 }
 
@@ -77,12 +77,10 @@ impl Ulid {
     /// ```
     #[must_use]
     pub fn new_ulid() -> ULID {
-        BASIC_ULID.with(|g| {
-            loop {
-                match g.next_id() {
-                    IdGenStatus::Ready { id } => break id,
-                    IdGenStatus::Pending { .. } => unreachable!(),
-                }
+        BASIC_ULID.with(|g| match g.next_id() {
+            IdGenStatus::Ready { id } => id,
+            IdGenStatus::Pending { .. } => {
+                unreachable!("A non-monotinic generator should never yield!")
             }
         })
     }

--- a/crates/ferroid/src/generator/ulid/thread_local.rs
+++ b/crates/ferroid/src/generator/ulid/thread_local.rs
@@ -1,14 +1,14 @@
 //! Thread-local ULID generation utilities.
 //!
-//! Provides high-performance, monotonic ULID generation using thread-local
-//! generators.
+//! Provides high-performance, non-monotonic and monotonic ULID generation using
+//! thread-local generators.
 //!
 //! In rare cases where the generator saturates within the same millisecond
 //! (monotonic overflow), it yields using the configured backoff strategy (e.g.,
 //! spin, yield, sleep). These overflows typically resolve within ~1ms.
 use crate::{
-    BasicUlidGenerator, Id, IdGenStatus, MonotonicClock, RandSource, ThreadRandom, ToU64, ULID,
-    UNIX_EPOCH,
+    BasicMonoUlidGenerator, BasicUlidGenerator, Id, IdGenStatus, MonotonicClock, RandSource,
+    ThreadRandom, ToU64, ULID, UNIX_EPOCH,
 };
 use std::sync::LazyLock;
 use std::thread_local;
@@ -19,9 +19,18 @@ static GLOBAL_MONOTONIC_CLOCK: LazyLock<MonotonicClock> =
     LazyLock::new(|| MonotonicClock::with_epoch(UNIX_EPOCH));
 
 thread_local! {
-    /// A thread-local ULID generator that reads from a global monotonic clock.
-    static BASIC_MONO_ULID: BasicUlidGenerator<ULID, MonotonicClock, ThreadRandom> =
+    /// A thread-local, non-monotonic ULID generator that reads from a global
+    /// monotonic clock.
+    static BASIC_ULID: BasicUlidGenerator<ULID, MonotonicClock, ThreadRandom> =
         BasicUlidGenerator::new(
+            GLOBAL_MONOTONIC_CLOCK.clone(),
+            ThreadRandom,
+        );
+
+    /// A thread-local, monotonic ULID generator that reads from a global
+    /// monotonic clock.
+    static BASIC_MONO_ULID: BasicMonoUlidGenerator<ULID, MonotonicClock, ThreadRandom> =
+        BasicMonoUlidGenerator::new(
             GLOBAL_MONOTONIC_CLOCK.clone(),
             ThreadRandom,
         );
@@ -52,58 +61,50 @@ pub enum Backoff {
     Sleep,
 }
 
-/// Generates a ULID using the specified [`Backoff`] strategy.
-///
-/// This is a convenient wrapper around [`ulid_mono_with_backoff`] with built-in
-/// strategies.
-fn ulid_mono(strategy: Backoff) -> ULID {
-    ulid_mono_with_backoff(|yield_for| match strategy {
-        Backoff::Spin => core::hint::spin_loop(),
-        Backoff::Yield => std::thread::yield_now(),
-        Backoff::Sleep => {
-            std::thread::sleep(core::time::Duration::from_millis(yield_for.to_u64()));
-        }
-    })
-}
+pub struct Ulid;
 
-/// Generates a ULID using a custom backoff strategy.
-///
-/// The provided function is called when the generator must wait before retrying
-/// due to ULID monotonic overflow. The `yield_for` argument indicates the
-/// recommended wait time in milliseconds.
-fn ulid_mono_with_backoff(f: impl Fn(<ULID as Id>::Ty)) -> ULID {
-    BASIC_MONO_ULID.with(|g| {
-        loop {
-            match g.next_id() {
-                IdGenStatus::Ready { id } => break id,
-                IdGenStatus::Pending { yield_for } => f(yield_for),
-            }
-        }
-    })
-}
-
-pub struct UlidMono;
-impl UlidMono {
-    /// Generates a ULID using [`Backoff::Yield`] as the overflow strategy.
-    ///
-    /// This is the default monotonic generator backed by a global, strictly
-    /// increasing clock and a thread-local random source.
+impl Ulid {
+    /// Generates a non-monotonic ULID that is always random, even when
+    /// generated within the same millisecond.
     ///
     /// # Example
     /// ```
     /// #[cfg(all(feature = "ulid", feature = "thread_local"))]
     /// {
-    ///     use ferroid::UlidMono;
-    ///     let id = UlidMono::new_ulid();
+    ///     use ferroid::Ulid;
+    ///     let id = Ulid::new_ulid();
     /// }
     /// ```
     #[must_use]
     pub fn new_ulid() -> ULID {
-        Self::with_backoff(Backoff::Yield)
+        BASIC_ULID.with(|g| {
+            loop {
+                match g.next_id() {
+                    IdGenStatus::Ready { id } => break id,
+                    IdGenStatus::Pending { .. } => unreachable!(),
+                }
+            }
+        })
     }
 
-    /// Generates a ULID using the given [`Backoff`] strategy to handle
-    /// overflow.
+    /// Generates a monotonic ULID using [`Backoff::Yield`] as the overflow
+    /// strategy.
+    ///
+    /// # Example
+    /// ```
+    /// #[cfg(all(feature = "ulid", feature = "thread_local"))]
+    /// {
+    ///     use ferroid::Ulid;
+    ///     let id = Ulid::new_mono_ulid();
+    /// }
+    /// ```
+    #[must_use]
+    pub fn new_mono_ulid() -> ULID {
+        Self::with_mono_backoff(Backoff::Yield)
+    }
+
+    /// Generates a monotonic ULID using the given [`Backoff`] strategy to
+    /// handle overflow.
     ///
     /// If the generator exhausts available entropy within the same millisecond,
     /// the backoff strategy determines how it waits before retrying.
@@ -112,13 +113,43 @@ impl UlidMono {
     /// ```
     /// #[cfg(all(feature = "ulid", feature = "thread_local"))]
     /// {
-    ///     use ferroid::{UlidMono, Backoff};
-    ///     let id = UlidMono::with_backoff(Backoff::Spin);
+    ///     use ferroid::{Ulid, Backoff};
+    ///     let id = Ulid::with_mono_backoff(Backoff::Spin);
     /// }
     /// ```
     #[must_use]
-    pub fn with_backoff(strategy: Backoff) -> ULID {
-        ulid_mono(strategy)
+    pub fn with_mono_backoff(strategy: Backoff) -> ULID {
+        Self::ulid_mono(strategy)
+    }
+
+    /// Generates a ULID using the specified [`Backoff`] strategy.
+    ///
+    /// This is a convenient wrapper around [`ulid_mono_with_backoff`] with
+    /// built-in strategies.
+    fn ulid_mono(strategy: Backoff) -> ULID {
+        Self::ulid_mono_with_backoff(|yield_for| match strategy {
+            Backoff::Spin => core::hint::spin_loop(),
+            Backoff::Yield => std::thread::yield_now(),
+            Backoff::Sleep => {
+                std::thread::sleep(core::time::Duration::from_millis(yield_for.to_u64()));
+            }
+        })
+    }
+
+    /// Generates a monotonic ULID using a custom backoff strategy.
+    ///
+    /// The provided function is called when the generator must wait before
+    /// retrying due to ULID monotonic overflow. The `yield_for` argument
+    /// indicates the recommended wait time in milliseconds.
+    fn ulid_mono_with_backoff(f: impl Fn(<ULID as Id>::Ty)) -> ULID {
+        BASIC_MONO_ULID.with(|g| {
+            loop {
+                match g.next_id() {
+                    IdGenStatus::Ready { id } => break id,
+                    IdGenStatus::Pending { yield_for } => f(yield_for),
+                }
+            }
+        })
     }
 
     /// Creates a ULID from a given millisecond timestamp.
@@ -130,8 +161,8 @@ impl UlidMono {
     /// ```
     /// #[cfg(all(feature = "ulid", feature = "thread_local"))]
     /// {
-    ///     use ferroid::UlidMono;
-    ///     let id = UlidMono::from_timestamp(1_694_201_234_000);
+    ///     use ferroid::Ulid;
+    ///     let id = Ulid::from_timestamp(1_694_201_234_000);
     /// }
     /// ```
     #[must_use]
@@ -148,8 +179,8 @@ impl UlidMono {
     /// ```
     /// #[cfg(all(feature = "ulid", feature = "thread_local"))]
     /// {
-    ///     use ferroid::{UlidMono, ThreadRandom};
-    ///     let id = UlidMono::from_timestamp_and_rand(0, &ThreadRandom);
+    ///     use ferroid::{Ulid, ThreadRandom};
+    ///     let id = Ulid::from_timestamp_and_rand(0, &ThreadRandom);
     /// }
     /// ```
     pub fn from_timestamp_and_rand<R>(timestamp: <ULID as Id>::Ty, rng: &R) -> ULID
@@ -161,15 +192,15 @@ impl UlidMono {
 
     /// Creates a ULID from a `SystemTime`.
     ///
-    /// This is a convenience wrapper over [`UlidMono::from_timestamp`] that
+    /// This is a convenience wrapper over [`Ulid::from_timestamp`] that
     /// extracts the Unix timestamp in milliseconds.
     ///
     /// # Example
     /// ```
     /// #[cfg(all(feature = "ulid", feature = "thread_local"))]
     /// {
-    ///     use ferroid::UlidMono;
-    ///     let id = UlidMono::from_datetime(std::time::SystemTime::now());
+    ///     use ferroid::Ulid;
+    ///     let id = Ulid::from_datetime(std::time::SystemTime::now());
     /// }
     /// ```
     #[must_use]
@@ -183,9 +214,9 @@ impl UlidMono {
     /// ```
     /// #[cfg(all(feature = "ulid", feature = "thread_local"))]
     /// {
-    ///     use ferroid::{UlidMono, ThreadRandom};
+    ///     use ferroid::{Ulid, ThreadRandom};
     ///     let now = std::time::SystemTime::now();
-    ///     let id = UlidMono::from_datetime_and_rand(now, &ThreadRandom);
+    ///     let id = Ulid::from_datetime_and_rand(now, &ThreadRandom);
     /// }
     /// ```
     pub fn from_datetime_and_rand<R>(datetime: std::time::SystemTime, rng: &R) -> ULID

--- a/crates/ferroid/src/generator/ulid/thread_local.rs
+++ b/crates/ferroid/src/generator/ulid/thread_local.rs
@@ -97,6 +97,7 @@ impl UlidMono {
     ///     let id = UlidMono::new_ulid();
     /// }
     /// ```
+    #[must_use]
     pub fn new_ulid() -> ULID {
         Self::with_backoff(Backoff::Yield)
     }
@@ -115,6 +116,7 @@ impl UlidMono {
     ///     let id = UlidMono::with_backoff(Backoff::Spin);
     /// }
     /// ```
+    #[must_use]
     pub fn with_backoff(strategy: Backoff) -> ULID {
         ulid_mono(strategy)
     }
@@ -132,6 +134,7 @@ impl UlidMono {
     ///     let id = UlidMono::from_timestamp(1_694_201_234_000);
     /// }
     /// ```
+    #[must_use]
     pub fn from_timestamp(timestamp: <ULID as Id>::Ty) -> ULID {
         ULID::from_timestamp(timestamp)
     }
@@ -169,6 +172,7 @@ impl UlidMono {
     ///     let id = UlidMono::from_datetime(std::time::SystemTime::now());
     /// }
     /// ```
+    #[must_use]
     pub fn from_datetime(datetime: std::time::SystemTime) -> ULID {
         ULID::from_datetime(datetime)
     }

--- a/crates/ferroid/src/id/snowflake.rs
+++ b/crates/ferroid/src/id/snowflake.rs
@@ -405,6 +405,7 @@ define_snowflake_id!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::println;
 
     #[test]
     fn test_snowflake_twitter_id_fields_and_bounds() {

--- a/crates/ferroid/src/id/snowflake.rs
+++ b/crates/ferroid/src/id/snowflake.rs
@@ -11,14 +11,14 @@ use core::{fmt, hash::Hash};
 /// # Example
 ///
 /// ```
-/// use ferroid::{Snowflake, SnowflakeTwitterId};
+/// use ferroid::{SnowflakeId, SnowflakeTwitterId};
 ///
 /// let id = SnowflakeTwitterId::from(1000, 2, 1);
 /// assert_eq!(id.timestamp(), 1000);
 /// assert_eq!(id.machine_id(), 2);
 /// assert_eq!(id.sequence(), 1);
 /// ```
-pub trait Snowflake:
+pub trait SnowflakeId:
     Id + Copy + Clone + fmt::Display + PartialOrd + Ord + PartialEq + Eq + Hash
 {
     /// Returns the timestamp portion of the ID.
@@ -240,7 +240,7 @@ macro_rules! define_snowflake_id {
             }
         }
 
-        impl $crate::Snowflake for $name {
+        impl $crate::SnowflakeId for $name {
             fn timestamp(&self) -> Self::Ty {
                 self.timestamp()
             }

--- a/crates/ferroid/src/id/snowflake.rs
+++ b/crates/ferroid/src/id/snowflake.rs
@@ -189,19 +189,19 @@ macro_rules! define_snowflake_id {
                 (self.id >> Self::SEQUENCE_SHIFT) & Self::SEQUENCE_MASK
             }
             /// Returns the maximum representable timestamp value based on
-            /// Self::TIMESTAMP_BITS.
+            /// `Self::TIMESTAMP_BITS`.
             #[must_use]
             pub const fn max_timestamp() -> $int {
                 (1 << Self::TIMESTAMP_BITS) - 1
             }
             /// Returns the maximum representable machine ID value based on
-            /// Self::MACHINE_ID_BITS.
+            /// `Self::MACHINE_ID_BITS`.
             #[must_use]
             pub const fn max_machine_id() -> $int {
                 (1 << Self::MACHINE_ID_BITS) - 1
             }
             /// Returns the maximum representable sequence value based on
-            /// Self::SEQUENCE_BITS.
+            /// `Self::SEQUENCE_BITS`.
             #[must_use]
             pub const fn max_sequence() -> $int {
                 (1 << Self::SEQUENCE_BITS) - 1

--- a/crates/ferroid/src/id/snowflake.rs
+++ b/crates/ferroid/src/id/snowflake.rs
@@ -415,7 +415,7 @@ define_snowflake_id!(
     sequence: 20
 );
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
     use std::println;

--- a/crates/ferroid/src/id/snowflake.rs
+++ b/crates/ferroid/src/id/snowflake.rs
@@ -30,7 +30,7 @@ pub trait Snowflake:
     /// Returns the machine ID portion of the ID.
     fn machine_id(&self) -> Self::Ty;
 
-    /// Returns the maximum possible value for the machine_id field.
+    /// Returns the maximum possible value for the `machine_id` field.
     fn max_machine_id() -> Self::Ty;
 
     /// Returns the sequence portion of the ID.
@@ -165,6 +165,7 @@ macro_rules! define_snowflake_id {
                 (Self::SEQUENCE_MASK << Self::SEQUENCE_SHIFT)
             }
 
+            #[must_use]
             pub const fn from(timestamp: $int, machine_id: $int, sequence: $int) -> Self {
                 let t = (timestamp & Self::TIMESTAMP_MASK) << Self::TIMESTAMP_SHIFT;
                 let m = (machine_id & Self::MACHINE_ID_MASK) << Self::MACHINE_ID_SHIFT;
@@ -173,39 +174,47 @@ macro_rules! define_snowflake_id {
             }
 
             /// Extracts the timestamp from the packed ID.
+            #[must_use]
             pub const fn timestamp(&self) -> $int {
                 (self.id >> Self::TIMESTAMP_SHIFT) & Self::TIMESTAMP_MASK
             }
             /// Extracts the machine ID from the packed ID.
+            #[must_use]
             pub const fn machine_id(&self) -> $int {
                 (self.id >> Self::MACHINE_ID_SHIFT) & Self::MACHINE_ID_MASK
             }
             /// Extracts the sequence number from the packed ID.
+            #[must_use]
             pub const fn sequence(&self) -> $int {
                 (self.id >> Self::SEQUENCE_SHIFT) & Self::SEQUENCE_MASK
             }
             /// Returns the maximum representable timestamp value based on
             /// Self::TIMESTAMP_BITS.
+            #[must_use]
             pub const fn max_timestamp() -> $int {
                 (1 << Self::TIMESTAMP_BITS) - 1
             }
             /// Returns the maximum representable machine ID value based on
             /// Self::MACHINE_ID_BITS.
+            #[must_use]
             pub const fn max_machine_id() -> $int {
                 (1 << Self::MACHINE_ID_BITS) - 1
             }
             /// Returns the maximum representable sequence value based on
             /// Self::SEQUENCE_BITS.
+            #[must_use]
             pub const fn max_sequence() -> $int {
                 (1 << Self::SEQUENCE_BITS) - 1
             }
 
             /// Converts this type into its raw type representation
+            #[must_use]
             pub const fn to_raw(&self) -> $int {
                 self.id
             }
 
             /// Converts a raw type into this type
+            #[must_use]
             pub const fn from_raw(raw: $int) -> Self {
                 Self { id: raw }
             }

--- a/crates/ferroid/src/id/snowflake.rs
+++ b/crates/ferroid/src/id/snowflake.rs
@@ -40,6 +40,7 @@ pub trait Snowflake:
     fn max_sequence() -> Self::Ty;
 
     /// Constructs a new Snowflake ID from its components.
+    #[must_use]
     fn from_components(timestamp: Self::Ty, machine_id: Self::Ty, sequence: Self::Ty) -> Self;
 
     /// Returns true if the current sequence value can be incremented.
@@ -53,11 +54,13 @@ pub trait Snowflake:
     }
 
     /// Returns a new ID with the sequence incremented.
+    #[must_use]
     fn increment_sequence(&self) -> Self {
         Self::from_components(self.timestamp(), self.machine_id(), self.next_sequence())
     }
 
     /// Returns a new ID for a newer timestamp with sequence reset to zero.
+    #[must_use]
     fn rollover_to_timestamp(&self, ts: Self::Ty) -> Self {
         Self::from_components(ts, self.machine_id(), Self::ZERO)
     }
@@ -68,6 +71,7 @@ pub trait Snowflake:
 
     /// Returns a normalized version of the ID with any invalid or reserved bits
     /// cleared. This guarantees a valid, canonical representation.
+    #[must_use]
     fn into_valid(self) -> Self;
 }
 
@@ -490,105 +494,105 @@ mod tests {
     #[should_panic(expected = "timestamp overflow")]
     fn twitter_timestamp_overflow_panics() {
         let ts = SnowflakeTwitterId::max_timestamp() + 1;
-        SnowflakeTwitterId::from_components(ts, 0, 0);
+        let _ = SnowflakeTwitterId::from_components(ts, 0, 0);
     }
 
     #[test]
     #[should_panic(expected = "machine_id overflow")]
     fn twitter_machine_id_overflow_panics() {
         let mid = SnowflakeTwitterId::max_machine_id() + 1;
-        SnowflakeTwitterId::from_components(0, mid, 0);
+        let _ = SnowflakeTwitterId::from_components(0, mid, 0);
     }
 
     #[test]
     #[should_panic(expected = "sequence overflow")]
     fn twitter_sequence_overflow_panics() {
         let seq = SnowflakeTwitterId::max_sequence() + 1;
-        SnowflakeTwitterId::from_components(0, 0, seq);
+        let _ = SnowflakeTwitterId::from_components(0, 0, seq);
     }
 
     #[test]
     #[should_panic(expected = "timestamp overflow")]
     fn discord_timestamp_overflow_panics() {
         let ts = SnowflakeDiscordId::max_timestamp() + 1;
-        SnowflakeDiscordId::from_components(ts, 0, 0);
+        let _ = SnowflakeDiscordId::from_components(ts, 0, 0);
     }
 
     #[test]
     #[should_panic(expected = "machine_id overflow")]
     fn discord_machine_id_overflow_panics() {
         let mid = SnowflakeDiscordId::max_machine_id() + 1;
-        SnowflakeDiscordId::from_components(0, mid, 0);
+        let _ = SnowflakeDiscordId::from_components(0, mid, 0);
     }
 
     #[test]
     #[should_panic(expected = "sequence overflow")]
     fn discord_sequence_overflow_panics() {
         let seq = SnowflakeDiscordId::max_sequence() + 1;
-        SnowflakeDiscordId::from_components(0, 0, seq);
+        let _ = SnowflakeDiscordId::from_components(0, 0, seq);
     }
 
     #[test]
     #[should_panic(expected = "timestamp overflow")]
     fn mastodon_timestamp_overflow_panics() {
         let ts = SnowflakeMastodonId::max_timestamp() + 1;
-        SnowflakeMastodonId::from_components(ts, 0, 0);
+        let _ = SnowflakeMastodonId::from_components(ts, 0, 0);
     }
 
     #[test]
     #[should_panic(expected = "machine_id overflow")]
     fn mastodon_machine_id_overflow_panics() {
         let mid = SnowflakeMastodonId::max_machine_id() + 1;
-        SnowflakeMastodonId::from_components(0, mid, 0);
+        let _ = SnowflakeMastodonId::from_components(0, mid, 0);
     }
 
     #[test]
     #[should_panic(expected = "sequence overflow")]
     fn mastodon_sequence_overflow_panics() {
         let seq = SnowflakeMastodonId::max_sequence() + 1;
-        SnowflakeMastodonId::from_components(0, 0, seq);
+        let _ = SnowflakeMastodonId::from_components(0, 0, seq);
     }
 
     #[test]
     #[should_panic(expected = "timestamp overflow")]
     fn instagram_timestamp_overflow_panics() {
         let ts = SnowflakeInstagramId::max_timestamp() + 1;
-        SnowflakeInstagramId::from_components(ts, 0, 0);
+        let _ = SnowflakeInstagramId::from_components(ts, 0, 0);
     }
 
     #[test]
     #[should_panic(expected = "machine_id overflow")]
     fn instagram_machine_id_overflow_panics() {
         let mid = SnowflakeInstagramId::max_machine_id() + 1;
-        SnowflakeInstagramId::from_components(0, mid, 0);
+        let _ = SnowflakeInstagramId::from_components(0, mid, 0);
     }
 
     #[test]
     #[should_panic(expected = "sequence overflow")]
     fn instagram_sequence_overflow_panics() {
         let seq = SnowflakeInstagramId::max_sequence() + 1;
-        SnowflakeInstagramId::from_components(0, 0, seq);
+        let _ = SnowflakeInstagramId::from_components(0, 0, seq);
     }
 
     #[test]
     #[should_panic(expected = "timestamp overflow")]
     fn long_timestamp_overflow_panics() {
         let ts = SnowflakeLongId::max_timestamp() + 1;
-        SnowflakeLongId::from_components(ts, 0, 0);
+        let _ = SnowflakeLongId::from_components(ts, 0, 0);
     }
 
     #[test]
     #[should_panic(expected = "machine_id overflow")]
     fn long_machine_id_overflow_panics() {
         let mid = SnowflakeLongId::max_machine_id() + 1;
-        SnowflakeLongId::from_components(0, mid, 0);
+        let _ = SnowflakeLongId::from_components(0, mid, 0);
     }
 
     #[test]
     #[should_panic(expected = "sequence overflow")]
     fn long_sequence_overflow_panics() {
         let seq = SnowflakeLongId::max_sequence() + 1;
-        SnowflakeLongId::from_components(0, 0, seq);
+        let _ = SnowflakeLongId::from_components(0, 0, seq);
     }
 
     #[test]

--- a/crates/ferroid/src/id/to_u64.rs
+++ b/crates/ferroid/src/id/to_u64.rs
@@ -18,19 +18,19 @@ pub trait ToU64 {
 
 impl ToU64 for u8 {
     fn to_u64(self) -> u64 {
-        self as u64
+        u64::from(self)
     }
 }
 
 impl ToU64 for u16 {
     fn to_u64(self) -> u64 {
-        self as u64
+        u64::from(self)
     }
 }
 
 impl ToU64 for u32 {
     fn to_u64(self) -> u64 {
-        self as u64
+        u64::from(self)
     }
 }
 

--- a/crates/ferroid/src/id/ulid.rs
+++ b/crates/ferroid/src/id/ulid.rs
@@ -7,7 +7,7 @@ use core::{fmt, hash::Hash};
 /// over a fixed-size integer (e.g., `u128`) used for high-entropy time-sortable
 /// ID generation.
 ///
-/// Types implementing `Ulid` expose methods for construction, encoding, and
+/// Types implementing `UlidId` expose methods for construction, encoding, and
 /// extracting field components from packed integers.
 pub trait UlidId:
     Id + Copy + Clone + fmt::Display + PartialOrd + Ord + PartialEq + Eq + Hash + fmt::Debug

--- a/crates/ferroid/src/id/ulid.rs
+++ b/crates/ferroid/src/id/ulid.rs
@@ -9,7 +9,7 @@ use core::{fmt, hash::Hash};
 ///
 /// Types implementing `Ulid` expose methods for construction, encoding, and
 /// extracting field components from packed integers.
-pub trait Ulid:
+pub trait UlidId:
     Id + Copy + Clone + fmt::Display + PartialOrd + Ord + PartialEq + Eq + Hash + fmt::Debug
 {
     /// Returns the timestamp portion of the ID.
@@ -263,7 +263,7 @@ macro_rules! define_ulid {
             }
         }
 
-        impl $crate::Ulid for $name {
+        impl $crate::UlidId for $name {
             fn timestamp(&self) -> Self::Ty {
                 self.timestamp()
             }

--- a/crates/ferroid/src/id/ulid.rs
+++ b/crates/ferroid/src/id/ulid.rs
@@ -194,8 +194,8 @@ macro_rules! define_ulid {
             /// generator.
             ///
             /// [`ThreadRandom`]: crate::ThreadRandom
-            #[cfg(feature = "thread_local")]
-            #[cfg_attr(not(feature = "thread_local"), doc(hidden))]
+            #[cfg(feature = "std")]
+            #[cfg_attr(not(feature = "std"), doc(hidden))]
             #[must_use]
             pub fn from_timestamp(timestamp: <Self as $crate::Id>::Ty) -> Self {
                 Self::from_timestamp_and_rand(timestamp, &$crate::ThreadRandom)
@@ -219,8 +219,8 @@ macro_rules! define_ulid {
             /// [`ThreadRandom`] random generator.
             ///
             /// [`ThreadRandom`]: crate::ThreadRandom
-            #[cfg(feature = "thread_local")]
-            #[cfg_attr(not(feature = "thread_local"), doc(hidden))]
+            #[cfg(feature = "std")]
+            #[cfg_attr(not(feature = "std"), doc(hidden))]
             #[must_use]
             pub fn from_datetime(datetime: std::time::SystemTime) -> Self {
                 Self::from_datetime_and_rand(datetime, &$crate::ThreadRandom)
@@ -339,7 +339,7 @@ define_ulid!(
     random: 80
 );
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
     use crate::RandSource;

--- a/crates/ferroid/src/id/ulid.rs
+++ b/crates/ferroid/src/id/ulid.rs
@@ -143,6 +143,7 @@ macro_rules! define_ulid {
                 (Self::RANDOM_MASK << Self::RANDOM_SHIFT)
             }
 
+            #[must_use]
             pub const fn from(timestamp: $int, random: $int) -> Self {
                 let t = (timestamp & Self::TIMESTAMP_MASK) << Self::TIMESTAMP_SHIFT;
                 let r = (random & Self::RANDOM_MASK) << Self::RANDOM_SHIFT;
@@ -150,30 +151,36 @@ macro_rules! define_ulid {
             }
 
             /// Extracts the timestamp from the packed ID.
+            #[must_use]
             pub const fn timestamp(&self) -> $int {
                 (self.id >> Self::TIMESTAMP_SHIFT) & Self::TIMESTAMP_MASK
             }
             /// Extracts the random number from the packed ID.
+            #[must_use]
             pub const fn random(&self) -> $int {
                 (self.id >> Self::RANDOM_SHIFT) & Self::RANDOM_MASK
             }
             /// Returns the maximum representable timestamp value based on
             /// Self::TIMESTAMP_BITS.
+            #[must_use]
             pub const fn max_timestamp() -> $int {
                 (1 << Self::TIMESTAMP_BITS) - 1
             }
             /// Returns the maximum representable randome value based on
             /// Self::RANDOM_BITS.
+            #[must_use]
             pub const fn max_random() -> $int {
                 (1 << Self::RANDOM_BITS) - 1
             }
 
             /// Converts this type into its raw type representation
+            #[must_use]
             pub const fn to_raw(&self) -> $int {
                 self.id
             }
 
             /// Converts a raw type into this type
+            #[must_use]
             pub const fn from_raw(raw: $int) -> Self {
                 Self { id: raw }
             }
@@ -185,6 +192,7 @@ macro_rules! define_ulid {
             /// [`ThreadRandom`]: crate::ThreadRandom
             #[cfg(feature = "thread_local")]
             #[cfg_attr(not(feature = "thread_local"), doc(hidden))]
+            #[must_use]
             pub fn from_timestamp(timestamp: <Self as $crate::Id>::Ty) -> Self {
                 Self::from_timestamp_and_rand(timestamp, &$crate::ThreadRandom)
             }
@@ -194,6 +202,7 @@ macro_rules! define_ulid {
             /// [`RandSource`]
             ///
             /// [`RandSource`]: crate::RandSource
+            #[must_use]
             pub fn from_timestamp_and_rand<R>(timestamp:  <Self as $crate::Id>::Ty, rng: &R) -> Self
             where
                 R: $crate::RandSource<<Self as $crate::Id>::Ty>,
@@ -208,6 +217,7 @@ macro_rules! define_ulid {
             /// [`ThreadRandom`]: crate::ThreadRandom
             #[cfg(feature = "thread_local")]
             #[cfg_attr(not(feature = "thread_local"), doc(hidden))]
+            #[must_use]
             pub fn from_datetime(datetime: std::time::SystemTime) -> Self {
                 Self::from_datetime_and_rand(datetime, &$crate::ThreadRandom)
             }
@@ -219,6 +229,7 @@ macro_rules! define_ulid {
             ///
             #[cfg(feature = "std")]
             #[cfg_attr(not(feature = "std"), doc(hidden))]
+            #[must_use]
             pub fn from_datetime_and_rand<R>(datetime: std::time::SystemTime, rng: &R) -> Self
             where
                 R: $crate::RandSource<<Self as $crate::Id>::Ty>,

--- a/crates/ferroid/src/id/ulid.rs
+++ b/crates/ferroid/src/id/ulid.rs
@@ -25,6 +25,7 @@ pub trait Ulid:
     fn max_random() -> Self::Ty;
 
     /// Constructs a new ULID from its components.
+    #[must_use]
     fn from_components(timestamp: Self::Ty, random: Self::Ty) -> Self;
 
     /// Returns true if the current sequence value can be incremented.
@@ -38,11 +39,13 @@ pub trait Ulid:
     }
 
     /// Returns a new ID with the random portion incremented.
+    #[must_use]
     fn increment_random(&self) -> Self {
         Self::from_components(self.timestamp(), self.next_random())
     }
 
     /// Returns a new ID for a newer timestamp with sequence reset to zero.
+    #[must_use]
     fn rollover_to_timestamp(&self, ts: Self::Ty, rand: Self::Ty) -> Self {
         Self::from_components(ts, rand)
     }
@@ -53,6 +56,7 @@ pub trait Ulid:
 
     /// Returns a normalized version of the ID with any invalid or reserved bits
     /// cleared. This guarantees a valid, canonical representation.
+    #[must_use]
     fn into_valid(self) -> Self;
 }
 

--- a/crates/ferroid/src/id/ulid.rs
+++ b/crates/ferroid/src/id/ulid.rs
@@ -183,6 +183,8 @@ macro_rules! define_ulid {
             /// generator.
             ///
             /// [`ThreadRandom`]: crate::ThreadRandom
+            #[cfg(feature = "thread_local")]
+            #[cfg_attr(not(feature = "thread_local"), doc(hidden))]
             pub fn from_timestamp(timestamp: <Self as $crate::Id>::Ty) -> Self {
                 Self::from_timestamp_and_rand(timestamp, &$crate::ThreadRandom)
             }
@@ -204,6 +206,8 @@ macro_rules! define_ulid {
             /// [`ThreadRandom`] random generator.
             ///
             /// [`ThreadRandom`]: crate::ThreadRandom
+            #[cfg(feature = "thread_local")]
+            #[cfg_attr(not(feature = "thread_local"), doc(hidden))]
             pub fn from_datetime(datetime: std::time::SystemTime) -> Self {
                 Self::from_datetime_and_rand(datetime, &$crate::ThreadRandom)
             }
@@ -212,6 +216,9 @@ macro_rules! define_ulid {
             /// number generator implementing [`RandSource`]
             ///
             /// [`RandSource`]: crate::RandSource
+            ///
+            #[cfg(feature = "std")]
+            #[cfg_attr(not(feature = "std"), doc(hidden))]
             pub fn from_datetime_and_rand<R>(datetime: std::time::SystemTime, rng: &R) -> Self
             where
                 R: $crate::RandSource<<Self as $crate::Id>::Ty>,
@@ -321,6 +328,7 @@ define_ulid!(
 mod tests {
     use super::*;
     use crate::RandSource;
+    use std::println;
 
     struct MockRand;
     impl RandSource<u128> for MockRand {

--- a/crates/ferroid/src/id/ulid.rs
+++ b/crates/ferroid/src/id/ulid.rs
@@ -161,13 +161,13 @@ macro_rules! define_ulid {
                 (self.id >> Self::RANDOM_SHIFT) & Self::RANDOM_MASK
             }
             /// Returns the maximum representable timestamp value based on
-            /// Self::TIMESTAMP_BITS.
+            /// `Self::TIMESTAMP_BITS`.
             #[must_use]
             pub const fn max_timestamp() -> $int {
                 (1 << Self::TIMESTAMP_BITS) - 1
             }
             /// Returns the maximum representable randome value based on
-            /// Self::RANDOM_BITS.
+            /// `Self::RANDOM_BIT`.
             #[must_use]
             pub const fn max_random() -> $int {
                 (1 << Self::RANDOM_BITS) - 1

--- a/crates/ferroid/src/lib.rs
+++ b/crates/ferroid/src/lib.rs
@@ -1,4 +1,20 @@
 #![doc = include_str!("../README.md")]
+#![no_std]
+
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use core::panic::PanicInfo;
+
+#[cfg(not(feature = "std"))]
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    loop {}
+}
 
 #[cfg(feature = "base32")]
 mod base32;
@@ -8,12 +24,14 @@ mod futures;
 #[cfg(any(feature = "snowflake", feature = "ulid"))]
 mod generator;
 mod id;
+#[cfg(all(feature = "std", feature = "alloc"))]
 mod mono_clock;
 #[cfg(feature = "ulid")]
 mod rand;
+#[cfg(any(feature = "async-tokio", feature = "async-smol"))]
 mod runtime;
 mod status;
-#[cfg(feature = "ulid")]
+#[cfg(feature = "thread_local")]
 mod thread_random;
 mod time;
 
@@ -25,12 +43,13 @@ pub use crate::futures::*;
 #[cfg(any(feature = "snowflake", feature = "ulid"))]
 pub use crate::generator::*;
 pub use crate::id::*;
+#[cfg(all(feature = "std", feature = "alloc"))]
 pub use crate::mono_clock::*;
 #[cfg(feature = "ulid")]
 pub use crate::rand::*;
 #[cfg(any(feature = "async-tokio", feature = "async-smol"))]
 pub use crate::runtime::*;
 pub use crate::status::*;
-#[cfg(feature = "ulid")]
+#[cfg(feature = "thread_local")]
 pub use crate::thread_random::*;
 pub use crate::time::*;

--- a/crates/ferroid/src/lib.rs
+++ b/crates/ferroid/src/lib.rs
@@ -7,15 +7,6 @@ extern crate std;
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-#[cfg(not(feature = "std"))]
-use core::panic::PanicInfo;
-
-#[cfg(not(feature = "std"))]
-#[panic_handler]
-fn panic(_info: &PanicInfo) -> ! {
-    loop {}
-}
-
 #[cfg(feature = "base32")]
 mod base32;
 mod error;

--- a/crates/ferroid/src/lib.rs
+++ b/crates/ferroid/src/lib.rs
@@ -17,12 +17,11 @@ mod generator;
 mod id;
 #[cfg(all(feature = "std", feature = "alloc"))]
 mod mono_clock;
-#[cfg(feature = "ulid")]
 mod rand;
 #[cfg(any(feature = "async-tokio", feature = "async-smol"))]
 mod runtime;
 mod status;
-#[cfg(feature = "thread_local")]
+#[cfg(feature = "std")]
 mod thread_random;
 mod time;
 
@@ -36,11 +35,10 @@ pub use crate::generator::*;
 pub use crate::id::*;
 #[cfg(all(feature = "std", feature = "alloc"))]
 pub use crate::mono_clock::*;
-#[cfg(feature = "ulid")]
 pub use crate::rand::*;
 #[cfg(any(feature = "async-tokio", feature = "async-smol"))]
 pub use crate::runtime::*;
 pub use crate::status::*;
-#[cfg(feature = "thread_local")]
+#[cfg(feature = "std")]
 pub use crate::thread_random::*;
 pub use crate::time::*;

--- a/crates/ferroid/src/mono_clock.rs
+++ b/crates/ferroid/src/mono_clock.rs
@@ -134,10 +134,7 @@ impl MonotonicClock {
             }
         });
 
-        inner
-            .handle
-            .set(handle)
-            .expect("failed to set thread handle");
+        let _ = inner.handle.set(handle);
 
         Self {
             inner,

--- a/crates/ferroid/src/mono_clock.rs
+++ b/crates/ferroid/src/mono_clock.rs
@@ -14,7 +14,7 @@ use std::{
 #[derive(Debug)]
 struct SharedTickerInner {
     current: AtomicU64,
-    _handle: OnceLock<JoinHandle<()>>,
+    handle: OnceLock<JoinHandle<()>>,
 }
 
 /// A monotonic time source that returns elapsed time since process start,
@@ -101,7 +101,7 @@ impl MonotonicClock {
 
         let inner = Arc::new(SharedTickerInner {
             current: AtomicU64::new(0),
-            _handle: OnceLock::new(),
+            handle: OnceLock::new(),
         });
 
         let weak_inner = Arc::downgrade(&inner);
@@ -135,7 +135,7 @@ impl MonotonicClock {
         });
 
         inner
-            ._handle
+            .handle
             .set(handle)
             .expect("failed to set thread handle");
 

--- a/crates/ferroid/src/mono_clock.rs
+++ b/crates/ferroid/src/mono_clock.rs
@@ -1,13 +1,15 @@
 use crate::{CUSTOM_EPOCH, TimeSource};
+use alloc::sync::Arc;
 use core::time::Duration;
 use std::{
     sync::{
-        Arc, OnceLock,
+        OnceLock,
         atomic::{AtomicU64, Ordering},
     },
     thread::{self, JoinHandle},
     time::{Instant, SystemTime, UNIX_EPOCH},
 };
+
 /// Shared ticker thread that updates every millisecond.
 #[derive(Debug)]
 struct SharedTickerInner {

--- a/crates/ferroid/src/mono_clock.rs
+++ b/crates/ferroid/src/mono_clock.rs
@@ -91,6 +91,7 @@ impl MonotonicClock {
     /// generated times to a custom epoch of your choosing.
     ///
     /// [`current_millis`]: TimeSource::current_millis
+    #[must_use]
     pub fn with_epoch(epoch: Duration) -> Self {
         let start = Instant::now();
         let system_now = SystemTime::now()
@@ -157,6 +158,6 @@ impl TimeSource<u128> for MonotonicClock {
     /// Returns the number of milliseconds since the configured epoch, based on
     /// the elapsed monotonic time since construction.
     fn current_millis(&self) -> u128 {
-        <Self as TimeSource<u64>>::current_millis(self) as u128
+        u128::from(<Self as TimeSource<u64>>::current_millis(self))
     }
 }

--- a/crates/ferroid/src/runtime/mod.rs
+++ b/crates/ferroid/src/runtime/mod.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "async-smol")]
 mod smol;
-#[cfg(feature = "async-tokio")]
+#[cfg(all(feature = "alloc", feature = "async-tokio"))]
 mod tokio;
 
 #[cfg(all(feature = "async-smol", feature = "snowflake"))]
@@ -18,7 +18,7 @@ pub use smol::*;
 pub use smol_snowflake::*;
 #[cfg(all(feature = "async-smol", feature = "ulid"))]
 pub use smol_ulid::*;
-#[cfg(feature = "async-tokio")]
+#[cfg(all(feature = "alloc", feature = "async-tokio"))]
 pub use tokio::*;
 #[cfg(all(feature = "async-tokio", feature = "snowflake"))]
 pub use tokio_snowflake::*;

--- a/crates/ferroid/src/runtime/smol_snowflake.rs
+++ b/crates/ferroid/src/runtime/smol_snowflake.rs
@@ -51,6 +51,7 @@ mod tests {
     use futures::future::try_join_all;
     use smol::Task;
     use std::collections::HashSet;
+    use std::vec::Vec;
 
     const TOTAL_IDS: usize = 4096;
     const NUM_GENERATORS: u64 = 8;

--- a/crates/ferroid/src/runtime/smol_snowflake.rs
+++ b/crates/ferroid/src/runtime/smol_snowflake.rs
@@ -32,9 +32,9 @@ where
 
 impl<G, ID, T> SnowflakeGeneratorAsyncSmolExt<ID, T> for G
 where
-    G: SnowflakeGenerator<ID, T>,
-    ID: Snowflake,
-    T: TimeSource<ID::Ty>,
+    G: SnowflakeGenerator<ID, T> + Sync,
+    ID: Snowflake + Send,
+    T: TimeSource<ID::Ty> + Send,
 {
     type Err = G::Err;
 
@@ -205,6 +205,7 @@ mod tests {
     ) -> Result<()> {
         let all_ids: Vec<_> = try_join_all(tasks).await?.into_iter().flatten().collect();
 
+        #[allow(clippy::cast_possible_truncation)]
         let expected_total = NUM_GENERATORS as usize * IDS_PER_GENERATOR;
         assert_eq!(
             all_ids.len(),

--- a/crates/ferroid/src/runtime/smol_snowflake.rs
+++ b/crates/ferroid/src/runtime/smol_snowflake.rs
@@ -1,4 +1,4 @@
-use crate::{Result, SmolSleep, Snowflake, SnowflakeGenerator, TimeSource};
+use crate::{Result, SmolSleep, SnowflakeGenerator, SnowflakeId, TimeSource};
 
 /// Extension trait for asynchronously generating Snowflake IDs using the
 /// [`smol`](https://docs.rs/smol) async runtime.
@@ -10,7 +10,7 @@ use crate::{Result, SmolSleep, Snowflake, SnowflakeGenerator, TimeSource};
 /// [`SleepProvider`]: crate::SleepProvider
 pub trait SnowflakeGeneratorAsyncSmolExt<ID, T>
 where
-    ID: Snowflake,
+    ID: SnowflakeId,
     T: TimeSource<ID::Ty>,
 {
     type Err;
@@ -33,7 +33,7 @@ where
 impl<G, ID, T> SnowflakeGeneratorAsyncSmolExt<ID, T> for G
 where
     G: SnowflakeGenerator<ID, T>,
-    ID: Snowflake,
+    ID: SnowflakeId,
     T: TimeSource<ID::Ty>,
 {
     type Err = G::Err;
@@ -49,7 +49,7 @@ mod tests {
     use super::*;
     use crate::{
         AtomicSnowflakeGenerator, LockSnowflakeGenerator, MonotonicClock, Result, SleepProvider,
-        SmolYield, Snowflake, SnowflakeGenerator, SnowflakeTwitterId, TimeSource,
+        SmolYield, SnowflakeGenerator, SnowflakeId, SnowflakeTwitterId, TimeSource,
     };
     use core::fmt;
     use futures::future::try_join_all;
@@ -136,7 +136,7 @@ mod tests {
     ) -> Result<()>
     where
         G: SnowflakeGenerator<ID, T> + Send + Sync + 'static,
-        ID: Snowflake + fmt::Debug + Send + 'static,
+        ID: SnowflakeId + fmt::Debug + Send + 'static,
         T: TimeSource<ID::Ty> + Clone + Send,
         S: SleepProvider,
     {
@@ -172,7 +172,7 @@ mod tests {
     ) -> Result<()>
     where
         G: SnowflakeGenerator<ID, T> + Send + Sync + 'static,
-        ID: Snowflake + fmt::Debug + Send + 'static,
+        ID: SnowflakeId + fmt::Debug + Send + 'static,
         T: TimeSource<ID::Ty> + Clone + Send,
     {
         let clock = clock_factory();
@@ -202,7 +202,7 @@ mod tests {
 
     // Helper to validate uniqueness - shared between test approaches
     async fn validate_unique_snow_ids(
-        tasks: Vec<Task<Result<Vec<impl Snowflake + fmt::Debug>>>>,
+        tasks: Vec<Task<Result<Vec<impl SnowflakeId + fmt::Debug>>>>,
     ) -> Result<()> {
         let all_ids: Vec<_> = try_join_all(tasks).await?.into_iter().flatten().collect();
 

--- a/crates/ferroid/src/runtime/smol_snowflake.rs
+++ b/crates/ferroid/src/runtime/smol_snowflake.rs
@@ -32,12 +32,13 @@ where
 
 impl<G, ID, T> SnowflakeGeneratorAsyncSmolExt<ID, T> for G
 where
-    G: SnowflakeGenerator<ID, T> + Sync,
-    ID: Snowflake + Send,
-    T: TimeSource<ID::Ty> + Send,
+    G: SnowflakeGenerator<ID, T>,
+    ID: Snowflake,
+    T: TimeSource<ID::Ty>,
 {
     type Err = G::Err;
 
+    #[allow(clippy::future_not_send)]
     fn try_next_id_async(&self) -> impl Future<Output = Result<ID, Self::Err>> {
         <Self as crate::SnowflakeGeneratorAsyncExt<ID, T>>::try_next_id_async::<SmolSleep>(self)
     }

--- a/crates/ferroid/src/runtime/smol_ulid.rs
+++ b/crates/ferroid/src/runtime/smol_ulid.rs
@@ -53,6 +53,7 @@ mod tests {
     use futures::future::try_join_all;
     use smol::Task;
     use std::collections::HashSet;
+    use std::vec::Vec;
 
     const TOTAL_IDS: usize = 4096;
     const NUM_GENERATORS: u64 = 8;
@@ -172,9 +173,7 @@ mod tests {
     }
 
     // Helper to validate uniqueness - shared between test approaches
-    async fn validate_unique_ulid_ids(
-        tasks: Vec<Task<Result<Vec<impl Ulid>>>>,
-    ) -> Result<()> {
+    async fn validate_unique_ulid_ids(tasks: Vec<Task<Result<Vec<impl Ulid>>>>) -> Result<()> {
         let all_ids: Vec<_> = try_join_all(tasks).await?.into_iter().flatten().collect();
 
         let expected_total = NUM_GENERATORS as usize * IDS_PER_GENERATOR;

--- a/crates/ferroid/src/runtime/smol_ulid.rs
+++ b/crates/ferroid/src/runtime/smol_ulid.rs
@@ -35,13 +35,14 @@ where
 
 impl<G, ID, T, R> UlidGeneratorAsyncSmolExt<ID, T, R> for G
 where
-    G: UlidGenerator<ID, T, R> + Sync,
-    ID: Ulid + Send,
-    T: TimeSource<ID::Ty> + Send,
-    R: RandSource<ID::Ty> + Send,
+    G: UlidGenerator<ID, T, R>,
+    ID: Ulid,
+    T: TimeSource<ID::Ty>,
+    R: RandSource<ID::Ty>,
 {
     type Err = G::Err;
 
+    #[allow(clippy::future_not_send)]
     fn try_next_id_async(&self) -> impl Future<Output = Result<ID, Self::Err>> {
         <Self as crate::UlidGeneratorAsyncExt<ID, T, R>>::try_next_id_async::<SmolSleep>(self)
     }

--- a/crates/ferroid/src/runtime/tokio.rs
+++ b/crates/ferroid/src/runtime/tokio.rs
@@ -1,4 +1,5 @@
 use crate::SleepProvider;
+use alloc::boxed::Box;
 use core::pin::Pin;
 
 /// An implementation of [`SleepProvider`] using Tokio's timer.

--- a/crates/ferroid/src/runtime/tokio_snowflake.rs
+++ b/crates/ferroid/src/runtime/tokio_snowflake.rs
@@ -125,7 +125,7 @@ mod tests {
         G: SnowflakeGenerator<ID, T> + Send + Sync + 'static,
         ID: Snowflake + fmt::Debug + Send + 'static,
         T: TimeSource<ID::Ty> + Clone + Send,
-        S: SleepProvider + Send,
+        S: SleepProvider,
     {
         let clock = clock_factory();
         let generators: Vec<_> = (0..NUM_GENERATORS)

--- a/crates/ferroid/src/runtime/tokio_snowflake.rs
+++ b/crates/ferroid/src/runtime/tokio_snowflake.rs
@@ -33,9 +33,9 @@ where
 
 impl<G, ID, T> SnowflakeGeneratorAsyncTokioExt<ID, T> for G
 where
-    G: SnowflakeGenerator<ID, T> + Sync,
-    ID: Snowflake + Send,
-    T: TimeSource<ID::Ty> + Send,
+    G: SnowflakeGenerator<ID, T>,
+    ID: Snowflake,
+    T: TimeSource<ID::Ty>,
 {
     type Err = G::Err;
 

--- a/crates/ferroid/src/runtime/tokio_snowflake.rs
+++ b/crates/ferroid/src/runtime/tokio_snowflake.rs
@@ -1,4 +1,4 @@
-use crate::{Result, SnowflakeId, SnowflakeGenerator, TimeSource, TokioSleep};
+use crate::{Result, SnowflakeGenerator, SnowflakeId, TimeSource, TokioSleep};
 use core::fmt;
 
 /// Extension trait for asynchronously generating Snowflake IDs using the
@@ -39,6 +39,7 @@ where
 {
     type Err = G::Err;
 
+    #[allow(clippy::future_not_send)]
     fn try_next_id_async(&self) -> impl Future<Output = Result<ID, Self::Err>> {
         <Self as crate::SnowflakeGeneratorAsyncExt<ID, T>>::try_next_id_async::<TokioSleep>(self)
     }
@@ -49,7 +50,7 @@ mod tests {
     use super::*;
     use crate::{
         AtomicSnowflakeGenerator, LockSnowflakeGenerator, MonotonicClock, Result, SleepProvider,
-        SnowflakeId, SnowflakeGenerator, SnowflakeTwitterId, TimeSource, TokioYield,
+        SnowflakeGenerator, SnowflakeId, SnowflakeTwitterId, TimeSource, TokioYield,
     };
     use core::fmt;
     use futures::future::try_join_all;

--- a/crates/ferroid/src/runtime/tokio_snowflake.rs
+++ b/crates/ferroid/src/runtime/tokio_snowflake.rs
@@ -1,4 +1,4 @@
-use crate::{Result, Snowflake, SnowflakeGenerator, TimeSource, TokioSleep};
+use crate::{Result, SnowflakeId, SnowflakeGenerator, TimeSource, TokioSleep};
 use core::fmt;
 
 /// Extension trait for asynchronously generating Snowflake IDs using the
@@ -11,7 +11,7 @@ use core::fmt;
 /// [`SleepProvider`]: crate::SleepProvider
 pub trait SnowflakeGeneratorAsyncTokioExt<ID, T>
 where
-    ID: Snowflake,
+    ID: SnowflakeId,
     T: TimeSource<ID::Ty>,
 {
     type Err: fmt::Debug;
@@ -34,7 +34,7 @@ where
 impl<G, ID, T> SnowflakeGeneratorAsyncTokioExt<ID, T> for G
 where
     G: SnowflakeGenerator<ID, T>,
-    ID: Snowflake,
+    ID: SnowflakeId,
     T: TimeSource<ID::Ty>,
 {
     type Err = G::Err;
@@ -49,7 +49,7 @@ mod tests {
     use super::*;
     use crate::{
         AtomicSnowflakeGenerator, LockSnowflakeGenerator, MonotonicClock, Result, SleepProvider,
-        Snowflake, SnowflakeGenerator, SnowflakeTwitterId, TimeSource, TokioYield,
+        SnowflakeId, SnowflakeGenerator, SnowflakeTwitterId, TimeSource, TokioYield,
     };
     use core::fmt;
     use futures::future::try_join_all;
@@ -123,7 +123,7 @@ mod tests {
     ) -> Result<()>
     where
         G: SnowflakeGenerator<ID, T> + Send + Sync + 'static,
-        ID: Snowflake + fmt::Debug + Send + 'static,
+        ID: SnowflakeId + fmt::Debug + Send + 'static,
         T: TimeSource<ID::Ty> + Clone + Send,
         S: SleepProvider,
     {
@@ -159,7 +159,7 @@ mod tests {
     ) -> Result<()>
     where
         G: SnowflakeGenerator<ID, T> + Send + Sync + 'static,
-        ID: Snowflake + fmt::Debug + Send + 'static,
+        ID: SnowflakeId + fmt::Debug + Send + 'static,
         T: TimeSource<ID::Ty> + Clone + Send,
     {
         let clock = clock_factory();
@@ -189,7 +189,7 @@ mod tests {
 
     // Helper to validate uniqueness - shared between test approaches
     async fn validate_unique_snow_ids(
-        tasks: Vec<tokio::task::JoinHandle<Result<Vec<impl Snowflake + fmt::Debug>>>>,
+        tasks: Vec<tokio::task::JoinHandle<Result<Vec<impl SnowflakeId + fmt::Debug>>>>,
     ) -> Result<()> {
         let all_ids: Vec<_> = try_join_all(tasks)
             .await

--- a/crates/ferroid/src/runtime/tokio_snowflake.rs
+++ b/crates/ferroid/src/runtime/tokio_snowflake.rs
@@ -50,6 +50,7 @@ mod tests {
     use core::fmt;
     use futures::future::try_join_all;
     use std::collections::HashSet;
+    use std::vec::Vec;
 
     const TOTAL_IDS: usize = 4096;
     const NUM_GENERATORS: u64 = 8;

--- a/crates/ferroid/src/runtime/tokio_ulid.rs
+++ b/crates/ferroid/src/runtime/tokio_ulid.rs
@@ -36,10 +36,10 @@ where
 
 impl<G, ID, T, R> UlidGeneratorAsyncTokioExt<ID, T, R> for G
 where
-    G: UlidGenerator<ID, T, R>,
-    ID: Ulid,
-    T: TimeSource<ID::Ty>,
-    R: RandSource<ID::Ty>,
+    G: UlidGenerator<ID, T, R> + Sync,
+    ID: Ulid + Send,
+    T: TimeSource<ID::Ty> + Send,
+    R: RandSource<ID::Ty> + Send,
 {
     type Err = G::Err;
 
@@ -184,6 +184,7 @@ mod tests {
             .flat_map(Result::unwrap)
             .collect();
 
+        #[allow(clippy::cast_possible_truncation)]
         let expected_total = NUM_GENERATORS as usize * IDS_PER_GENERATOR;
         assert_eq!(
             all_ids.len(),

--- a/crates/ferroid/src/runtime/tokio_ulid.rs
+++ b/crates/ferroid/src/runtime/tokio_ulid.rs
@@ -36,13 +36,14 @@ where
 
 impl<G, ID, T, R> UlidGeneratorAsyncTokioExt<ID, T, R> for G
 where
-    G: UlidGenerator<ID, T, R> + Sync,
-    ID: Ulid + Send,
-    T: TimeSource<ID::Ty> + Send,
-    R: RandSource<ID::Ty> + Send,
+    G: UlidGenerator<ID, T, R>,
+    ID: Ulid,
+    T: TimeSource<ID::Ty>,
+    R: RandSource<ID::Ty>,
 {
     type Err = G::Err;
 
+    #[allow(clippy::future_not_send)]
     fn try_next_id_async(&self) -> impl Future<Output = Result<ID, Self::Err>> {
         <Self as crate::UlidGeneratorAsyncExt<ID, T, R>>::try_next_id_async::<TokioSleep>(self)
     }

--- a/crates/ferroid/src/runtime/tokio_ulid.rs
+++ b/crates/ferroid/src/runtime/tokio_ulid.rs
@@ -52,6 +52,7 @@ mod tests {
     use core::fmt;
     use futures::future::try_join_all;
     use std::collections::HashSet;
+    use std::vec::Vec;
 
     const TOTAL_IDS: usize = 4096;
     const NUM_GENERATORS: u64 = 8;

--- a/crates/ferroid/src/status.rs
+++ b/crates/ferroid/src/status.rs
@@ -15,7 +15,7 @@ use crate::Id;
 /// ```
 /// #[cfg(feature = "snowflake")]
 /// {
-///     use ferroid::{Snowflake, BasicSnowflakeGenerator, SnowflakeTwitterId, IdGenStatus};
+///     use ferroid::{SnowflakeId, BasicSnowflakeGenerator, SnowflakeTwitterId, IdGenStatus};
 ///
 ///     struct FixedTime;
 ///     impl ferroid::TimeSource<u64> for FixedTime {

--- a/crates/ferroid/src/thread_random.rs
+++ b/crates/ferroid/src/thread_random.rs
@@ -1,7 +1,7 @@
 use crate::RandSource;
 use rand::{Rng, rng};
 
-/// A `RandSource` that uses the thread-local RNG (`rand::thread_rng()`).
+/// A `RandSource` that uses the thread-local RNG (`rand::thread_local()`).
 ///
 /// This RNG is fast, cryptographically secure (ChaCha-based), and automatically
 /// reseeded periodically.


### PR DESCRIPTION
This PR introduces a major architectural refactor across `ferroid`. The primary goals are to enable `no_std` compatibility, introduce fine-grained feature gating, and improve decoding semantics and testability across environments. We also refactor ULID generation to support both monotonic and non-monotonic generator behavior.

**Note**: Currently, there is no implementation for a `RandomSource` or `TimeSource` that will work in a `no_std` setting (no generators will work out of the box); however, this PR sets up the precedence to add such implementations in a future PR.

## Highlights

### `no_std` Support

* The crate now compiles with `#![no_std]`.
* Optional `std` and `alloc` features to allow fine grain control over `no_std` vs `no_std + alloc`. 
* No features are enabled by default.

### ULID Changes
* Supports both monotonic and non-monotonic ULID generators: `BasicUlidGenerator` and `BasicMonoUlidGenerator` respectively.

### Feature Gating and Runtime Segmentation

All optional functionality is now explicitly gated behind features:

* `std`: enables the lock-based generators and `ThreadRandom`.
* `alloc`: enables allocating functions such as the `MonotonicClock`
* `thread_local`: implies "std", "alloc" and enables `UlidMono` (the thread local generator)
* `ulid`: core ULID functionality
* `snowflake`: core Snowflake functionality
* `base32`: encode/decode extensions
* `tracing`: tracing on generators
* `serde`: serialization on the ID struct instead of the underlying integer representation
* `async-tokio`: implies "std", "alloc", "futures" and enables non-blocking async ID generation for Tokio
* `async-smol`: implies "std", "alloc", "futures" and enables non-blocking async ID generation for Smol
* `futures`: enables `SleepProvider`

### Improved Base32 Decode Semantics

* Decoders now return `Result<T, Error<E>>` where errors include the parsed (but invalid) ID.
* `Base32Error<E>` is now generic over the overflow type. In particular, `Base32Error::DecodeOverflow(E)` includes the ID type (e.g., `SnowflakeTwitterId`, `ULID`) with invalid reserved bits.
* Enables safe, allocation-free fallback handling. You can extract the inner value from `Base32Error::DecodeOverflow(E)` and call `.into_valid()` to clear the invalid reserved bits.
* Works in both `no_std` and `std` environments.

## Breaking Changes
* To support the previous `std` environment, users will need to additionally specify `std` and `alloc` feature flags.
* Error types are now generic: `Error<E>` and `Base32Error<E>`. APIs return `Result<T, E>` instead of `Result<T>`, with `E` defaulting to `core::convert::Infallible` in infallible cases.
* `to_string()` methods are gated behind the `alloc` feature and are unavailable in minimal configurations.
* `UlidMono::new()` has been renamed to `UlidMono::new_ulid()` to avoid confusion with the type constructor.
* `UlidMono` and its thread-local generation logic are now gated under the `thread_local` feature, supporting environments where thread locals are unsupported or unnecessary (e.g., `no_std`).
* `BasicUlidGenerator`s previous implementation has been renamed and moved to `BasicMonoUlidGenerator` respectively. `BasicUlidGenerator` is now non-monotonic and thread-safe.
* `LockUlidGenerator`s previous implementation has been renamed and moved to `LockMonoUlidGenerator` respectively. There's no need for a `LockUlidGenerator` as there's no internal state to maintain - users should use `BasicUlidGenerator` instead.
* `Snowflake` trait renamed to `SnowflakeId`
* `Ulid` trait renamed to `UlidId`
* `UlidMono` renamed to `Ulid`
