### PR TITLE
Refactor decoding errors, unify clock behavior, and remove legacy footguns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferroid"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-lock",
  "base32",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "ferroid-tonic-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "ferroid",
  "prost",
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "ferroid-tonic-server"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,14 +7,13 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Nick Angelou <angelou.nick@gmail.com>"]
 readme = "README.md"
 repository = "https://github.com/s0l0ist/ferroid"
 documentation = "https://docs.rs/ferroid"
-keywords = ["id", "snowflake", "ulid", "uuid", "monotonic"]
 
 [workspace.dependencies]
 anyhow = { version = "1.0", default-features = false }

--- a/crates/ferroid-tonic-core/Cargo.toml
+++ b/crates/ferroid-tonic-core/Cargo.toml
@@ -12,11 +12,11 @@ categories = [
   "network-programming", # Shared logic for a gRPC-based service
 ]
 documentation.workspace = true
-keywords.workspace = true
+keywords = ["ferroid", "grpc", "tonic", "snowflake", "ulid", "monotonic"]
 publish = true
 
 [dependencies]
-ferroid = { version = "0.6.0", path = "../ferroid", features = ["std", "alloc", "snowflake"] }
+ferroid = { version = "0.6.1", path = "../ferroid", features = ["std", "alloc", "snowflake"] }
 prost = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tonic = { workspace = true, features = ["prost", "codegen"] }

--- a/crates/ferroid-tonic-core/src/common/types.rs
+++ b/crates/ferroid-tonic-core/src/common/types.rs
@@ -42,7 +42,7 @@
 //! > binary encoding. To change the format, fork or wrap the binary crate and
 //! > inject your own implementation.
 
-use ferroid::{BasicSnowflakeGenerator, CUSTOM_EPOCH, Id, MonotonicClock, SnowflakeTwitterId};
+use ferroid::{BasicSnowflakeGenerator, Id, MonotonicClock, SnowflakeTwitterId, TWITTER_EPOCH};
 
 /// The canonical Snowflake ID type used across the system.
 ///
@@ -67,8 +67,8 @@ pub type Clock = MonotonicClock;
 /// The epoch offset used as the zero-point for timestamp calculations.
 ///
 /// This value is subtracted from the system clock to produce smaller, monotonic
-/// timestamps. Defaults to [`CUSTOM_EPOCH`].
-pub const EPOCH: core::time::Duration = CUSTOM_EPOCH;
+/// timestamps. Defaults to [`TWITTER_EPOCH`].
+pub const EPOCH: core::time::Duration = TWITTER_EPOCH;
 
 /// The default Snowflake ID generator used by each worker.
 ///

--- a/crates/ferroid-tonic-server/Cargo.toml
+++ b/crates/ferroid-tonic-server/Cargo.toml
@@ -14,7 +14,7 @@ categories = [
   "concurrency",             # Threaded workers / mpsc / stream batching
 ]
 documentation.workspace = true
-keywords.workspace = true
+keywords = ["ferroid", "grpc", "tonic", "snowflake", "ulid", "monotonic"]
 publish = true
 
 [[bin]]
@@ -26,7 +26,7 @@ anyhow = { workspace = true, features = ["std"] }
 bytes = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "color", "error-context", "help", "std", "suggestions", "usage"] }
 dotenvy = { workspace = true }
-ferroid-tonic-core = { version = "0.6.0", path = "../ferroid-tonic-core" }
+ferroid-tonic-core = { version = "0.6.1", path = "../ferroid-tonic-core" }
 futures = { workspace = true }
 mimalloc = { workspace = true }
 opentelemetry = { workspace = true, optional = true }

--- a/crates/ferroid/Cargo.toml
+++ b/crates/ferroid/Cargo.toml
@@ -15,7 +15,7 @@ categories = [
   "development-tools"   # Broad utility for developers building systems
 ]
 documentation.workspace = true
-keywords.workspace = true
+keywords = ["no_std", "id", "snowflake", "ulid", "uuid", "monotonic"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ferroid/README.md
+++ b/crates/ferroid/README.md
@@ -156,9 +156,10 @@ This allows any 13-character Base32 string to decode into a u64, or any
 26-character string into a u128, correctly **as long as reserved layout
 constraints aren't violated**.
 
-If reserved bits are set, Ferroid returns a `DecodeOverflow(id)` error with the
-full decoded (but invalid) ID. You can recover by calling `.into_valid()` to
-mask off reserved bits allowing explicit error handling or silent recovery.
+If reserved bits are set, Ferroid returns an error, `Base32Error::DecodeOverflow
+{ id }`, containing the full decoded (but invalid) ID. You can recover by
+calling `.into_valid()` to mask off reserved bits allowing explicit error
+handling or silent recovery.
 
 ### Generate an ID
 

--- a/crates/ferroid/src/base32/crockford.rs
+++ b/crates/ferroid/src/base32/crockford.rs
@@ -97,7 +97,9 @@ where
         // SAFETY: `b as usize` is in 0..=255, and `LOOKUP` has 256 entries.
         let val = unsafe { *LOOKUP.get_unchecked(b as usize) };
         if val == NO_VALUE {
-            return Err(Error::Base32Error(Base32Error::DecodeInvalidAscii(b)));
+            return Err(Error::Base32Error(Base32Error::DecodeInvalidAscii {
+                byte: b,
+            }));
         }
         acc = (acc << BITS_PER_CHAR) | T::from(val);
     }
@@ -200,7 +202,7 @@ mod tests {
         let res = decode_base32::<u32, ()>(s);
         assert!(res.is_err());
         match res.unwrap_err() {
-            Error::Base32Error(Base32Error::DecodeInvalidAscii(b'!')) => {}
+            Error::Base32Error(Base32Error::DecodeInvalidAscii { byte: b'!' }) => {}
             e => panic!("unexpected error: {e:?}"),
         }
     }

--- a/crates/ferroid/src/base32/error.rs
+++ b/crates/ferroid/src/base32/error.rs
@@ -3,16 +3,16 @@ use core::fmt;
 
 #[derive(Clone, Debug)]
 pub enum Base32Error<E> {
-    DecodeInvalidLen(usize),
-    DecodeInvalidAscii(u8),
-    DecodeOverflow(E),
+    DecodeInvalidLen { len: usize },
+    DecodeInvalidAscii { byte: u8 },
+    DecodeOverflow { id: E },
 }
 impl<E: core::fmt::Debug> fmt::Display for Base32Error<E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::DecodeInvalidAscii(b) => write!(f, "invalid ascii byte: {b}"),
-            Self::DecodeInvalidLen(len) => write!(f, "invalid length: {len}"),
-            Self::DecodeOverflow(data) => write!(f, "decode overflow: {data:#?}"),
+            Self::DecodeInvalidAscii { byte } => write!(f, "invalid ascii byte: {byte}"),
+            Self::DecodeInvalidLen { len } => write!(f, "invalid length: {len}"),
+            Self::DecodeOverflow { id } => write!(f, "decode overflow: {id:#?}"),
         }
     }
 }

--- a/crates/ferroid/src/base32/error.rs
+++ b/crates/ferroid/src/base32/error.rs
@@ -12,7 +12,7 @@ impl<E: core::fmt::Debug> fmt::Display for Base32Error<E> {
         match self {
             Self::DecodeInvalidAscii(b) => write!(f, "invalid ascii byte: {b}"),
             Self::DecodeInvalidLen(len) => write!(f, "invalid length: {len}"),
-            Self::DecodeOverflow(bytes) => write!(f, "decode overflow: {bytes:X?}"),
+            Self::DecodeOverflow(data) => write!(f, "decode overflow: {data:#?}"),
         }
     }
 }

--- a/crates/ferroid/src/base32/interface.rs
+++ b/crates/ferroid/src/base32/interface.rs
@@ -66,9 +66,9 @@ where
     fn inner_decode<E>(s: impl AsRef<str>) -> Result<Self, Error<E>> {
         let s_ref = s.as_ref();
         if s_ref.len() != Self::Ty::BASE32_SIZE {
-            return Err(Error::Base32Error(Base32Error::DecodeInvalidLen(
-                s_ref.len(),
-            )));
+            return Err(Error::Base32Error(Base32Error::DecodeInvalidLen {
+                len: s_ref.len(),
+            }));
         }
         let raw = super::decode_base32(s_ref)?;
         Ok(Self::from_raw(raw))

--- a/crates/ferroid/src/base32/snowflake.rs
+++ b/crates/ferroid/src/base32/snowflake.rs
@@ -143,9 +143,9 @@ where
     ///
     ///     let id = SnowflakeTwitterId::decode("FZZZZZZZZZZZZ").or_else(|err| {
     ///         match err {
-    ///             Error::Base32Error(Base32Error::DecodeOverflow(invalid)) => {
-    ///                 debug_assert!(!invalid.is_valid());
-    ///                 let valid = invalid.into_valid(); // clears reserved bits
+    ///             Error::Base32Error(Base32Error::DecodeOverflow { id }) => {
+    ///                 debug_assert!(!id.is_valid());
+    ///                 let valid = id.into_valid(); // clears reserved bits
     ///                 debug_assert!(valid.is_valid());
     ///                 Ok(valid)
     ///             }
@@ -157,7 +157,9 @@ where
     fn decode(s: impl AsRef<str>) -> Result<Self, Error<Self>> {
         let decoded = Self::inner_decode(s)?;
         if !decoded.is_valid() {
-            return Err(Error::Base32Error(Base32Error::DecodeOverflow(decoded)));
+            return Err(Error::Base32Error(Base32Error::DecodeOverflow {
+                id: decoded,
+            }));
         }
         Ok(decoded)
     }
@@ -508,7 +510,9 @@ mod test {
         let result = SnowflakeTwitterId::decode(invalid);
         assert!(matches!(
             result,
-            Err(Error::Base32Error(Base32Error::DecodeInvalidAscii(64)))
+            Err(Error::Base32Error(Base32Error::DecodeInvalidAscii {
+                byte: 64
+            }))
         ));
     }
 
@@ -519,7 +523,9 @@ mod test {
         let result = SnowflakeTwitterId::decode(too_short);
         assert!(matches!(
             result,
-            Err(Error::Base32Error(Base32Error::DecodeInvalidLen(12)))
+            Err(Error::Base32Error(Base32Error::DecodeInvalidLen {
+                len: 12
+            }))
         ));
 
         // Longer than 13-byte base32 for u64 (decoded slice won't be 8 bytes)
@@ -527,7 +533,9 @@ mod test {
         let result = SnowflakeTwitterId::decode(too_long);
         assert!(matches!(
             result,
-            Err(Error::Base32Error(Base32Error::DecodeInvalidLen(14)))
+            Err(Error::Base32Error(Base32Error::DecodeInvalidLen {
+                len: 14
+            }))
         ));
     }
 }

--- a/crates/ferroid/src/base32/ulid.rs
+++ b/crates/ferroid/src/base32/ulid.rs
@@ -140,7 +140,9 @@ where
     fn decode(s: impl AsRef<str>) -> Result<Self, Error<Self>> {
         let decoded = Self::inner_decode(s)?;
         if !decoded.is_valid() {
-            return Err(Error::Base32Error(Base32Error::DecodeOverflow(decoded)));
+            return Err(Error::Base32Error(Base32Error::DecodeOverflow {
+                id: decoded,
+            }));
         }
         Ok(decoded)
     }

--- a/crates/ferroid/src/generator/snowflake/basic.rs
+++ b/crates/ferroid/src/generator/snowflake/basic.rs
@@ -62,10 +62,16 @@ where
     /// ```
     /// #[cfg(all(feature = "std", feature = "alloc", feature = "snowflake"))]
     /// {
-    ///     use ferroid::{BasicSnowflakeGenerator, SnowflakeTwitterId, MonotonicClock};
+    ///     use ferroid::{BasicSnowflakeGenerator, IdGenStatus, SnowflakeTwitterId, TWITTER_EPOCH, MonotonicClock};
+    ///     
+    ///     let generator = BasicSnowflakeGenerator::new(0, MonotonicClock::with_epoch(TWITTER_EPOCH));
     ///
-    ///     let generator = BasicSnowflakeGenerator::<SnowflakeTwitterId, _>::new(0, MonotonicClock::default());
-    ///     let id = generator.next_id();
+    ///     let id: SnowflakeTwitterId = loop {
+    ///         match generator.next_id() {
+    ///             IdGenStatus::Ready { id } => break id,
+    ///             IdGenStatus::Pending { .. } => core::hint::spin_loop(),
+    ///         }
+    ///     };
     /// }
     /// ```
     ///
@@ -122,22 +128,16 @@ where
     /// ```
     /// #[cfg(all(feature = "std", feature = "alloc", feature = "snowflake"))]
     /// {
-    ///     use ferroid::{BasicSnowflakeGenerator, SnowflakeTwitterId, IdGenStatus, MonotonicClock, TimeSource};
+    ///     use ferroid::{BasicSnowflakeGenerator, IdGenStatus, SnowflakeTwitterId, TWITTER_EPOCH, MonotonicClock};
+    ///     
+    ///     let generator = BasicSnowflakeGenerator::new(0, MonotonicClock::with_epoch(TWITTER_EPOCH));
     ///
-    ///     // Create a clock and a generator with machine_id = 0
-    ///     let clock = MonotonicClock::default();
-    ///     let generator = BasicSnowflakeGenerator::<SnowflakeTwitterId, _>::new(0, clock);
-    ///
-    ///     // Attempt to generate a new ID
-    ///     match generator.next_id() {
-    ///         IdGenStatus::Ready { id } => {
-    ///             println!("ID: {}", id);
-    ///             assert_eq!(id.machine_id(), 0);
+    ///     let id: SnowflakeTwitterId = loop {
+    ///         match generator.next_id() {
+    ///             IdGenStatus::Ready { id } => break id,
+    ///             IdGenStatus::Pending { .. } => std::thread::yield_now(),
     ///         }
-    ///         IdGenStatus::Pending { yield_for } => {
-    ///             println!("Exhausted; wait for: {}ms", yield_for);
-    ///         }
-    ///     }
+    ///     };
     /// }
     /// ```
     pub fn next_id(&self) -> IdGenStatus<ID> {
@@ -156,7 +156,7 @@ where
     /// - `Ok(IdGenStatus::Ready { id })`: A new ID is available
     /// - `Ok(IdGenStatus::Pending { yield_for })`: The time to wait (in
     ///   milliseconds) before trying again
-    /// - `Err(e)`: A recoverable error occurred (e.g., time source failure)
+    /// - `Err(_)`: infallible for this generator
     ///
     /// # Errors
     /// - This method currently does not return any errors and always returns
@@ -166,23 +166,20 @@ where
     /// ```
     /// #[cfg(all(feature = "std", feature = "alloc", feature = "snowflake"))]
     /// {
-    ///     use ferroid::{BasicSnowflakeGenerator, SnowflakeTwitterId, IdGenStatus, MonotonicClock, TimeSource};
-    ///
-    ///     // Create a clock and a generator with machine_id = 0
-    ///     let clock = MonotonicClock::default();
-    ///     let generator = BasicSnowflakeGenerator::<SnowflakeTwitterId, _>::new(0, clock);
+    ///     use ferroid::{BasicSnowflakeGenerator, ToU64, IdGenStatus, SnowflakeTwitterId, TWITTER_EPOCH, MonotonicClock};
+    ///     
+    ///     let generator = BasicSnowflakeGenerator::new(0, MonotonicClock::with_epoch(TWITTER_EPOCH));
     ///
     ///     // Attempt to generate a new ID
-    ///     match generator.try_next_id() {
-    ///         Ok(IdGenStatus::Ready { id }) => {
-    ///             println!("ID: {}", id);
-    ///             assert_eq!(id.machine_id(), 0);
+    ///     let id: SnowflakeTwitterId = loop {
+    ///         match generator.try_next_id() {
+    ///             Ok(IdGenStatus::Ready { id }) => break id,
+    ///             Ok(IdGenStatus::Pending { yield_for }) => {
+    ///                 std::thread::sleep(core::time::Duration::from_millis(yield_for.to_u64()));
+    ///             }
+    ///             Err(_) => unreachable!(),
     ///         }
-    ///         Ok(IdGenStatus::Pending { yield_for }) => {
-    ///             println!("Exhausted; wait for: {}ms", yield_for);
-    ///         }
-    ///         Err(e) => eprintln!("Generator error: {}", e),
-    ///     }
+    ///     };
     /// }
     /// ```
     #[cfg_attr(feature = "tracing", instrument(level = "trace", skip(self)))]

--- a/crates/ferroid/src/generator/snowflake/mod.rs
+++ b/crates/ferroid/src/generator/snowflake/mod.rs
@@ -9,6 +9,5 @@ mod tests;
 pub use atomic::*;
 pub use basic::*;
 pub use interface::*;
-
 #[cfg(all(feature = "std", feature = "alloc"))]
 pub use lock::*;

--- a/crates/ferroid/src/generator/ulid/basic_mono.rs
+++ b/crates/ferroid/src/generator/ulid/basic_mono.rs
@@ -58,11 +58,16 @@ where
     /// ```
     /// #[cfg(all(feature = "std", feature = "alloc", feature = "ulid"))]
     /// {
-    ///     use ferroid::{BasicMonoUlidGenerator, ULID, MonotonicClock, ThreadRandom};
+    ///     use ferroid::{BasicMonoUlidGenerator, IdGenStatus, ULID, MonotonicClock, ThreadRandom};
+    ///     
+    ///     let generator = BasicMonoUlidGenerator::new(MonotonicClock::default(), ThreadRandom::default());
     ///
-    ///     let generator = BasicMonoUlidGenerator::<ULID, _, _>::new(MonotonicClock::default(), ThreadRandom::default());
-    ///     let id = generator.next_id();
-    ///     println!("Generated ID: {:?}", id);
+    ///     let id: ULID = loop {
+    ///         match generator.next_id() {
+    ///             IdGenStatus::Ready { id } => break id,
+    ///             IdGenStatus::Pending { .. } => core::hint::spin_loop(),
+    ///         }
+    ///     };
     /// }
     /// ```
     ///
@@ -116,20 +121,15 @@ where
     /// #[cfg(all(feature = "std", feature = "alloc", feature = "ulid"))]
     /// {
     ///     use ferroid::{BasicMonoUlidGenerator, IdGenStatus, ULID, MonotonicClock, ThreadRandom};
+    ///     
+    ///     let generator = BasicMonoUlidGenerator::new(MonotonicClock::default(), ThreadRandom::default());
     ///
-    ///     let clock = MonotonicClock::default();
-    ///     let rand = ThreadRandom::default();
-    ///     let generator = BasicMonoUlidGenerator::<ULID, _, _>::new(clock, rand);
-    ///
-    ///     // Attempt to generate a new ID
-    ///     match generator.next_id() {
-    ///         IdGenStatus::Ready { id } => {
-    ///             println!("ID: {}", id);
+    ///     let id: ULID = loop {
+    ///         match generator.next_id() {
+    ///             IdGenStatus::Ready { id } => break id,
+    ///             IdGenStatus::Pending { .. } => std::thread::yield_now(),
     ///         }
-    ///         IdGenStatus::Pending { yield_for } => {
-    ///             println!("Exhausted; wait for: {}ms", yield_for);
-    ///         }
-    ///     }
+    ///     };
     /// }
     /// ```
     pub fn next_id(&self) -> IdGenStatus<ID> {
@@ -142,10 +142,10 @@ where
     /// produce a unique identifier. Returns [`IdGenStatus::Ready`] on success.
     ///
     /// # Returns
-    /// - Ok(IdGenStatus::Ready { id }) A ULID was generated
-    /// - Ok(IdGenStatus::Pending { yield_for }) Never, but kept to match the
-    ///   Snowflake API
-    /// - Err(e) if the time source or rand source failed
+    /// - `Ok(IdGenStatus::Ready { id })`: A new ID is available
+    /// - `Ok(IdGenStatus::Pending { yield_for })`: The time to wait (in
+    ///   milliseconds) before trying again
+    /// - `Err(_)`: infallible for this generator
     ///
     /// # Errors
     /// - This method currently does not return any errors and always returns
@@ -155,22 +155,20 @@ where
     /// ```
     /// #[cfg(all(feature = "std", feature = "alloc", feature = "ulid"))]
     /// {
-    ///     use ferroid::{BasicMonoUlidGenerator, IdGenStatus, ULID, MonotonicClock, ThreadRandom};
+    ///     use ferroid::{BasicMonoUlidGenerator, IdGenStatus, ULID, ToU64, MonotonicClock, ThreadRandom};
     ///
-    ///     let clock = MonotonicClock::default();
-    ///     let rand = ThreadRandom::default();
-    ///     let generator = BasicMonoUlidGenerator::<ULID, _, _>::new(clock, rand);
+    ///     let generator = BasicMonoUlidGenerator::new(MonotonicClock::default(), ThreadRandom::default());
     ///
     ///     // Attempt to generate a new ID
-    ///     match generator.try_next_id() {
-    ///         Ok(IdGenStatus::Ready { id }) => {
-    ///             println!("ID: {}", id);
+    ///     let id: ULID = loop {
+    ///         match generator.try_next_id() {
+    ///             Ok(IdGenStatus::Ready { id }) => break id,
+    ///             Ok(IdGenStatus::Pending { yield_for }) => {
+    ///                 std::thread::sleep(core::time::Duration::from_millis(yield_for.to_u64()));
+    ///             }
+    ///             Err(_) => unreachable!(),
     ///         }
-    ///         Ok(IdGenStatus::Pending { yield_for }) => {
-    ///             println!("Exhausted; wait for: {}ms", yield_for);
-    ///         }
-    ///         Err(e) => eprintln!("Generator error: {}", e),
-    ///     }
+    ///     };
     /// }
     /// ```
     #[cfg_attr(feature = "tracing", instrument(level = "trace", skip(self)))]

--- a/crates/ferroid/src/id/snowflake.rs
+++ b/crates/ferroid/src/id/snowflake.rs
@@ -395,7 +395,7 @@ define_snowflake_id!(
     /// A 128-bit Snowflake ID using a hybrid layout.
     ///
     /// - 40 bits reserved
-    /// - 48 bits timestamp (ms since [`CUSTOM_EPOCH`])
+    /// - 48 bits timestamp
     /// - 20 bits machine ID
     /// - 20 bits sequence
     ///
@@ -407,7 +407,6 @@ define_snowflake_id!(
     ///              |<----- HI 64 bits ----->|<-------------- LO 64 bits ------------->|
     ///              |<--- MSB ------ LSB --->|<----- MSB ----- 64 bits ----- LSB ----->|
     /// ```
-    /// [`CUSTOM_EPOCH`]: crate::CUSTOM_EPOCH
     SnowflakeLongId, u128,
     reserved: 40,
     timestamp: 48,

--- a/crates/ferroid/src/mono_clock.rs
+++ b/crates/ferroid/src/mono_clock.rs
@@ -1,4 +1,4 @@
-use crate::{CUSTOM_EPOCH, TimeSource};
+use crate::{TimeSource, UNIX_EPOCH};
 use alloc::sync::Arc;
 use core::time::Duration;
 use std::{
@@ -7,7 +7,7 @@ use std::{
         atomic::{AtomicU64, Ordering},
     },
     thread::{self, JoinHandle},
-    time::{Instant, SystemTime, UNIX_EPOCH},
+    time::{Instant, SystemTime},
 };
 
 /// Shared ticker thread that updates every millisecond.
@@ -33,11 +33,11 @@ pub struct MonotonicClock {
 }
 
 impl Default for MonotonicClock {
-    /// Constructs a monotonic clock aligned to the default [`CUSTOM_EPOCH`].
+    /// Constructs a monotonic clock aligned to the default [`UNIX_EPOCH`].
     ///
     /// Panics if system time is earlier than the custom epoch.
     fn default() -> Self {
-        Self::with_epoch(CUSTOM_EPOCH)
+        Self::with_epoch(UNIX_EPOCH)
     }
 }
 
@@ -100,7 +100,7 @@ impl MonotonicClock {
     pub fn with_epoch(epoch: Duration) -> Self {
         let start = Instant::now();
         let system_now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
+            .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or(core::time::Duration::ZERO);
         #[allow(clippy::cast_possible_truncation)]
         let offset = system_now.saturating_sub(epoch).as_millis() as u64;

--- a/crates/ferroid/src/time.rs
+++ b/crates/ferroid/src/time.rs
@@ -3,9 +3,6 @@ use core::time::Duration;
 /// Unix epoch: Thursday, January 1, 1970 00:00:00 UTC
 pub const UNIX_EPOCH: Duration = Duration::from_millis(0);
 
-/// Custom epoch: Wednesday, January 1, 2025 00:00:00 UTC
-pub const CUSTOM_EPOCH: Duration = Duration::from_millis(1_735_689_600_000);
-
 /// Twitter epoch: Thursday, November 4, 2010 1:42:54.657 UTC
 pub const TWITTER_EPOCH: Duration = Duration::from_millis(1_288_834_974_657);
 


### PR DESCRIPTION
#### General improvements
- Simplified all doc examples to use loop + match idioms instead of manual branching.
- Switched clock constructors to `MonotonicClock::with_epoch(...)` for consistency across generators.
- Clarified and contrasted Ferroid's decoding behavior with the [official ULID spec](https://github.com/ulid/spec), including documentation examples.
- Removed a few items that exposed a footgun (`CUSTOM_EPOCH`) and redundant structs (`SnowflakeLongId`)

## ⚠️ Breaking Changes

### 1. Base32Error Variant Shape Changed

Refactored `Base32Error` to use struct-style enum variants with named fields instead of tuple variants:

Before:
```rust
Base32Error::DecodeInvalidAscii(u8)
Base32Error::DecodeInvalidLen(usize)
Base32Error::DecodeOverflow(E)
```
After:
```rust
Base32Error::DecodeInvalidAscii { byte: u8 }
Base32Error::DecodeInvalidLen { len: usize }
Base32Error::DecodeOverflow { id: E }
```

This is helpful for debug printing and improved ergonomics on `DecodeOverflow` and how to convert the `id` to a valid state (i.e.`id.into_valid()`).

### 2. Removed `CUSTOM_EPOCH` Constant

`CUSTOM_EPOCH` was removed in favor of using `UNIX_EPOCH `or type-specific constants like `TWITTER_EPOCH`, `MASTODON_EPOCH`, etc. This was arbitrarily defined by me when I first published this crate; however, it has no other meaning - especially in the context of other built-in ID types which require their on offsets. Therefore, removing it to prevent misuse.

### 3. `MonotonicClock::default()`'s default offset

The biggest change  is that the default clock now uses `UNIX_EPOCH` instead of `CUSTOM_EPOCH`. This was to avoid unexpected behavior from a default implementation. The default should be from unix epoch and not some custom offset.

### 4. Removed `SnowflakeLongId`

This was an artifact of showcasing how to construct a 128-bit snowflake ID, but the layout format was randomly chosen and not scientific at all - therefore, no serious user would actually use the 'dummy' implementation. I've opted to remove it to prevent misuse. Users are encouraged to create their own custom layout which can easily replicate the previous behavior.