### PR TITLE
Better documentation for base32 `decode` and its behavior

### DIFF
--- a/crates/ferroid/README.md
+++ b/crates/ferroid/README.md
@@ -157,7 +157,7 @@ Ferroid takes a more flexible stance:
 This allows any 13-character Base32 string to decode into a `u64`, or any
 26-character string into a `u128`, **as long as reserved layout constraints
 aren't violated**. If the layout defines no reserved bits, decoding is always
-valid.
+considered valid.
 
 For example:
 
@@ -167,7 +167,7 @@ For example:
 
 If reserved bits are set during decoding, Ferroid returns a
 `Base32Error::DecodeOverflow { id }` containing the full (invalid) ID. You can
-recover by calling `.into_valid()` to mask off reserved bits—allowing either
+recover by calling `.into_valid()` to mask off reserved bits-allowing either
 explicit error handling or silent correction.
 
 ### Generate an ID

--- a/crates/ferroid/src/base32/crockford.rs
+++ b/crates/ferroid/src/base32/crockford.rs
@@ -42,8 +42,6 @@ const LOOKUP: [u8; 256] = {
 ///     indices are valid.
 ///   - Therefore, `ALPHABET[(acc >> bits) & 0x1F]` is guaranteed to be
 ///     in-bounds.
-#[inline(always)]
-#[allow(clippy::inline_always)]
 pub fn encode_base32(input: &[u8], buf_slice: &mut [u8]) {
     let input_bits = input.len() * 8;
     let output_chars = buf_slice.len();
@@ -82,8 +80,6 @@ pub fn encode_base32(input: &[u8], buf_slice: &mut [u8]) {
 /// - `encoded.bytes()` produces values in the range 0..=255.
 /// - `LOOKUP` is a fixed-size array of 256 elements, so `LOOKUP[b as usize]` is
 ///   always in-bounds.
-#[inline(always)]
-#[allow(clippy::inline_always)]
 pub fn decode_base32<T, E>(encoded: &str) -> Result<T, Error<E>>
 where
     T: BeBytes

--- a/crates/ferroid/src/generator/ulid/thread_local.rs
+++ b/crates/ferroid/src/generator/ulid/thread_local.rs
@@ -80,7 +80,7 @@ impl Ulid {
         BASIC_ULID.with(|g| match g.next_id() {
             IdGenStatus::Ready { id } => id,
             IdGenStatus::Pending { .. } => {
-                unreachable!("A non-monotinic generator should never yield!")
+                unreachable!("A non-monotonic generator should never yield!")
             }
         })
     }

--- a/crates/ferroid/src/id/snowflake.rs
+++ b/crates/ferroid/src/id/snowflake.rs
@@ -231,12 +231,12 @@ macro_rules! define_snowflake_id {
 
             /// Converts this type into its raw type representation
             fn to_raw(&self) -> Self::Ty {
-                self.id
+                self.to_raw()
             }
 
             /// Converts a raw type into this type
             fn from_raw(raw: Self::Ty) -> Self {
-                Self { id: raw }
+                Self::from_raw(raw)
             }
         }
 

--- a/crates/ferroid/src/id/ulid.rs
+++ b/crates/ferroid/src/id/ulid.rs
@@ -254,12 +254,12 @@ macro_rules! define_ulid {
 
             /// Converts this type into its raw type representation
             fn to_raw(&self) -> Self::Ty {
-                self.id
+                self.to_raw()
             }
 
             /// Converts a raw type into this type
             fn from_raw(raw: Self::Ty) -> Self {
-                Self { id: raw }
+                Self::from_raw(raw)
             }
         }
 


### PR DESCRIPTION
Also fixes an error message (spelling) and removes unnecessary inlining.