### PR TITLE
 Remove default `Display` impl for IDs, enable via `base32` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferroid"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "async-lock",
  "base32",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "ferroid-tonic-core"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "ferroid",
  "prost",
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "ferroid-tonic-server"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Nick Angelou <angelou.nick@gmail.com>"]

--- a/crates/ferroid-tonic-core/Cargo.toml
+++ b/crates/ferroid-tonic-core/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["ferroid", "grpc", "snowflake", "ulid", "monotonic"]
 publish = true
 
 [dependencies]
-ferroid = { version = "0.6.2", path = "../ferroid", features = ["std", "alloc", "snowflake"] }
+ferroid = { version = "0.6.3", path = "../ferroid", features = ["std", "alloc", "snowflake"] }
 prost = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tonic = { workspace = true, features = ["prost", "codegen"] }

--- a/crates/ferroid-tonic-server/Cargo.toml
+++ b/crates/ferroid-tonic-server/Cargo.toml
@@ -26,7 +26,7 @@ anyhow = { workspace = true, features = ["std"] }
 bytes = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "color", "error-context", "help", "std", "suggestions", "usage"] }
 dotenvy = { workspace = true }
-ferroid-tonic-core = { version = "0.6.2", path = "../ferroid-tonic-core" }
+ferroid-tonic-core = { version = "0.6.3", path = "../ferroid-tonic-core" }
 futures = { workspace = true }
 mimalloc = { workspace = true }
 opentelemetry = { workspace = true, optional = true }

--- a/crates/ferroid/README.md
+++ b/crates/ferroid/README.md
@@ -82,13 +82,14 @@ alone can guarantee.
 ### Crockford Base32
 
 Enable the `base32` feature to support Crockford Base32 encoding and decoding
-IDs.
+IDs. Useful if you need fixed-width, URL-safe, and lexicographically sortable
+strings (e.g. for use in databases, logs, or URLs).
 
-By default, printing an ID returns its raw integer representation. If you need
-fixed-width, URL-safe, and lexicographically sortable strings (e.g. for use in
-databases, logs, or URLs), use `.encode()` to obtain a lightweight formatter. It
-can be passed freely without committing to any specific string primitive,
-letting the consumer choose how and when to render it.
+If the `base32` feature is enabled, the ID type will automatically implement
+`fmt::Display`. For maximum control over allocations, use `.encode()` to obtain
+a lightweight formatter. It can be passed freely without committing to any
+specific string primitive, letting the consumer choose how and when to render
+it.
 
 The formatter design avoids heap allocation by default and supports both owned
 and borrowed encoding buffers. For full `String` support, enable the `alloc`
@@ -100,7 +101,7 @@ feature.
     use ferroid::{Base32SnowExt, Base32SnowFormatter, SnowflakeId, SnowflakeTwitterId};
 
     let id = SnowflakeTwitterId::from(123456, 1, 42);
-    assert_eq!(format!("default: {id}"), "default: 517811998762");
+    assert_eq!(format!("default: {id}"), "default: 00000F280041A");
 
     let encoded: Base32SnowFormatter<SnowflakeTwitterId> = id.encode();
     assert_eq!(format!("base32: {encoded}"), "base32: 00000F280041A");
@@ -114,7 +115,7 @@ feature.
     use ferroid::{Base32UlidExt, Base32UlidFormatter, UlidId, ULID};
 
     let id = ULID::from(123456, 42);
-    assert_eq!(format!("default: {id}"), "default: 149249145986343659392525664298");
+    assert_eq!(format!("default: {id}"), "default: 0000003RJ0000000000000001A");
 
     let encoded: Base32UlidFormatter<ULID> = id.encode();
     assert_eq!(format!("base32: {encoded}"), "base32: 0000003RJ0000000000000001A");

--- a/crates/ferroid/src/base32/snowflake.rs
+++ b/crates/ferroid/src/base32/snowflake.rs
@@ -407,6 +407,23 @@ mod test {
     };
 
     #[test]
+    fn snow_try_from() {
+        // Don't need to test all IDs
+        let id = SnowflakeTwitterId::try_from("01ARZ3NDEKTSV").unwrap();
+        let encoded = id.encode();
+        assert_eq!(encoded, "01ARZ3NDEKTSV");
+    }
+
+    #[test]
+    fn snow_from_str() {
+        // Don't need to test all IDs
+        use core::str::FromStr;
+        let id = SnowflakeTwitterId::from_str("01ARZ3NDEKTSV").unwrap();
+        let encoded = id.encode();
+        assert_eq!(encoded, "01ARZ3NDEKTSV");
+    }
+
+    #[test]
     fn twitter_max() {
         let id = SnowflakeTwitterId::from_components(
             SnowflakeTwitterId::max_timestamp(),

--- a/crates/ferroid/src/base32/snowflake.rs
+++ b/crates/ferroid/src/base32/snowflake.rs
@@ -365,6 +365,40 @@ where
     }
 }
 
+#[cfg(all(test, feature = "alloc", feature = "snowflake"))]
+mod alloc_test {
+    use crate::{
+        Base32SnowExt, SnowflakeDiscordId, SnowflakeInstagramId, SnowflakeMastodonId,
+        SnowflakeTwitterId,
+    };
+    use alloc::string::ToString;
+
+    #[test]
+    fn twitter_display() {
+        let id = SnowflakeTwitterId::decode("01ARZ3NDEKTSV").unwrap();
+        assert_eq!(alloc::format!("{id}"), "01ARZ3NDEKTSV");
+        assert_eq!(id.to_string(), "01ARZ3NDEKTSV");
+    }
+    #[test]
+    fn instagram_display() {
+        let id = SnowflakeInstagramId::decode("01ARZ3NDEKTSV").unwrap();
+        assert_eq!(alloc::format!("{id}"), "01ARZ3NDEKTSV");
+        assert_eq!(id.to_string(), "01ARZ3NDEKTSV");
+    }
+    #[test]
+    fn mastodon_display() {
+        let id = SnowflakeMastodonId::decode("01ARZ3NDEKTSV").unwrap();
+        assert_eq!(alloc::format!("{id}"), "01ARZ3NDEKTSV");
+        assert_eq!(id.to_string(), "01ARZ3NDEKTSV");
+    }
+    #[test]
+    fn discord_display() {
+        let id = SnowflakeDiscordId::decode("01ARZ3NDEKTSV").unwrap();
+        assert_eq!(alloc::format!("{id}"), "01ARZ3NDEKTSV");
+        assert_eq!(id.to_string(), "01ARZ3NDEKTSV");
+    }
+}
+
 #[cfg(all(test, feature = "snowflake"))]
 mod test {
     use crate::{

--- a/crates/ferroid/src/base32/ulid.rs
+++ b/crates/ferroid/src/base32/ulid.rs
@@ -341,6 +341,19 @@ where
     }
 }
 
+#[cfg(all(test, feature = "alloc", feature = "ulid"))]
+mod alloc_test {
+    use crate::{Base32UlidExt, ULID};
+    use alloc::string::ToString;
+
+    #[test]
+    fn ulid_display() {
+        let ulid = ULID::decode("01ARZ3NDEKTSV4RRFFQ69G5FAV").unwrap();
+        assert_eq!(alloc::format!("{ulid}"), "01ARZ3NDEKTSV4RRFFQ69G5FAV");
+        assert_eq!(ulid.to_string(), "01ARZ3NDEKTSV4RRFFQ69G5FAV");
+    }
+}
+
 #[cfg(all(test, feature = "ulid"))]
 mod test {
     use crate::{Base32UlidExt, ULID, UlidId};

--- a/crates/ferroid/src/base32/ulid.rs
+++ b/crates/ferroid/src/base32/ulid.rs
@@ -359,6 +359,21 @@ mod test {
     use crate::{Base32UlidExt, ULID, UlidId};
 
     #[test]
+    fn ulid_try_from() {
+        let ulid = ULID::try_from("01ARZ3NDEKTSV4RRFFQ69G5FAV").unwrap();
+        let encoded = ulid.encode();
+        assert_eq!(encoded, "01ARZ3NDEKTSV4RRFFQ69G5FAV");
+    }
+
+    #[test]
+    fn ulid_from_str() {
+        use core::str::FromStr;
+        let ulid = ULID::from_str("01ARZ3NDEKTSV4RRFFQ69G5FAV").unwrap();
+        let encoded = ulid.encode();
+        assert_eq!(encoded, "01ARZ3NDEKTSV4RRFFQ69G5FAV");
+    }
+
+    #[test]
     fn ulid_max() {
         let id = ULID::from_components(ULID::max_timestamp(), ULID::max_random());
         assert_eq!(id.timestamp(), ULID::max_timestamp());

--- a/crates/ferroid/src/generator/snowflake/tests.rs
+++ b/crates/ferroid/src/generator/snowflake/tests.rs
@@ -71,7 +71,7 @@ where
 
     fn unwrap_pending(self) -> T::Ty {
         match self {
-            Self::Ready { id } => panic!("unexpected ready ({id})"),
+            Self::Ready { id } => panic!("unexpected ready ({id:?})"),
             Self::Pending { yield_for } => yield_for,
         }
     }

--- a/crates/ferroid/src/generator/ulid/tests.rs
+++ b/crates/ferroid/src/generator/ulid/tests.rs
@@ -99,7 +99,7 @@ where
 
     fn unwrap_pending(self) -> T::Ty {
         match self {
-            Self::Ready { id } => panic!("unexpected ready ({id})"),
+            Self::Ready { id } => panic!("unexpected ready ({id:?})"),
             Self::Pending { yield_for } => yield_for,
         }
     }

--- a/crates/ferroid/src/id/display.rs
+++ b/crates/ferroid/src/id/display.rs
@@ -1,0 +1,10 @@
+/// Helper to implement `fmt::Display` when the `base32` feature is enabled.
+#[macro_export]
+macro_rules! cfg_base32 {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "base32")]
+            $item
+        )*
+    };
+}

--- a/crates/ferroid/src/id/interface.rs
+++ b/crates/ferroid/src/id/interface.rs
@@ -13,9 +13,7 @@ use core::ops::{
 ///
 /// Types implementing `Id` must define a scalar type `Ty` and provide
 /// conversion to/from this raw representation.
-pub trait Id:
-    Copy + Clone + fmt::Display + PartialOrd + Ord + PartialEq + Eq + Hash + fmt::Debug
-{
+pub trait Id: Copy + Clone + PartialOrd + Ord + PartialEq + Eq + Hash + fmt::Debug {
     /// Zero value (used for resetting the sequence)
     const ZERO: Self::Ty;
 

--- a/crates/ferroid/src/id/mod.rs
+++ b/crates/ferroid/src/id/mod.rs
@@ -1,3 +1,4 @@
+mod display;
 mod interface;
 #[cfg(feature = "snowflake")]
 mod snowflake;

--- a/crates/ferroid/src/id/snowflake.rs
+++ b/crates/ferroid/src/id/snowflake.rs
@@ -277,9 +277,12 @@ macro_rules! define_snowflake_id {
             }
         }
 
-        impl core::fmt::Display for $name {
-            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                write!(f, "{}", self.id)
+        $crate::cfg_base32! {
+            impl core::fmt::Display for $name {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    use $crate::Base32SnowExt;
+                    self.encode().fmt(f)
+                }
             }
         }
 

--- a/crates/ferroid/src/id/snowflake.rs
+++ b/crates/ferroid/src/id/snowflake.rs
@@ -284,6 +284,24 @@ macro_rules! define_snowflake_id {
                     self.encode().fmt(f)
                 }
             }
+
+            impl core::convert::TryFrom<&str> for $name {
+                type Error = $crate::Error<$name>;
+
+                fn try_from(s: &str) -> Result<Self, Self::Error> {
+                    use $crate::Base32SnowExt;
+                    Self::decode(s)
+                }
+            }
+
+            impl core::str::FromStr for $name {
+                type Err = $crate::Error<$name>;
+
+                fn from_str(s: &str) -> Result<Self, Self::Err> {
+                    use $crate::Base32SnowExt;
+                    Self::decode(s)
+                }
+            }
         }
 
         impl core::fmt::Debug for $name {

--- a/crates/ferroid/src/id/ulid.rs
+++ b/crates/ferroid/src/id/ulid.rs
@@ -295,9 +295,12 @@ macro_rules! define_ulid {
             }
         }
 
-        impl core::fmt::Display for $name {
-            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                write!(f, "{}", self.id)
+        $crate::cfg_base32! {
+            impl core::fmt::Display for $name {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    use $crate::Base32UlidExt;
+                    self.encode().fmt(f)
+                }
             }
         }
 

--- a/crates/ferroid/src/id/ulid.rs
+++ b/crates/ferroid/src/id/ulid.rs
@@ -302,6 +302,24 @@ macro_rules! define_ulid {
                     self.encode().fmt(f)
                 }
             }
+
+            impl core::convert::TryFrom<&str> for $name {
+                type Error = $crate::Error<$name>;
+
+                fn try_from(s: &str) -> Result<Self, Self::Error> {
+                    use $crate::Base32UlidExt;
+                    Self::decode(s)
+                }
+            }
+
+            impl core::str::FromStr for $name {
+                type Err = $crate::Error<$name>;
+
+                fn from_str(s: &str) -> Result<Self, Self::Err> {
+                    use $crate::Base32UlidExt;
+                    Self::decode(s)
+                }
+            }
         }
 
         impl core::fmt::Debug for $name {


### PR DESCRIPTION
This PR removes the default `fmt::Display` implementation for all ID types and makes it opt-in via the `base32 `feature.

The previous `Display` implementation printed the raw numeric ID value (e.g., a `u64` or `u128`), which is not human-friendly and not typically useful in logs, URLs, or APIs. In most real-world cases, consumers need a fixed-width, sortable, URL-safe string format - such as Base32 - which was only available through `.encode()`.

By removing the default `Display`, we avoid misleading or unhelpful output when someone prints an ID. Instead, `Display` is only implemented when the `base32` feature is enabled, where it produces a canonical, encoded string that is actually useful.

To get the previous behavior, users can call `.to_raw()` (e.g., `ULID.to_raw()`) which returns the underlying scalar type that automatically implements `Display`, etc.

When the `base32` feature is enabled:
- Display prints the Base32-encoded string via `.encode()` internally
- `TryFrom<&str>` and `FromStr` are implemented and decode via `.decode()` internally

Users can still use the `.encode()` to get a formatter that allows more granular control over allocations.