### PR TITLE
remove unnecessary `fmt::Debug` trait bounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferroid"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "async-lock",
  "base32",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "ferroid-tonic-core"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "ferroid",
  "prost",
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "ferroid-tonic-server"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 rust-version = "1.81"
 license = "MIT OR Apache-2.0"

--- a/crates/ferroid-tonic-core/Cargo.toml
+++ b/crates/ferroid-tonic-core/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["ferroid", "grpc", "snowflake", "ulid", "monotonic"]
 publish = true
 
 [dependencies]
-ferroid = { version = "0.6.4", path = "../ferroid", features = ["std", "alloc", "snowflake"] }
+ferroid = { version = "0.6.5", path = "../ferroid", features = ["std", "alloc", "snowflake"] }
 prost = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tonic = { workspace = true, features = ["prost", "codegen"] }

--- a/crates/ferroid-tonic-server/Cargo.toml
+++ b/crates/ferroid-tonic-server/Cargo.toml
@@ -27,7 +27,7 @@ anyhow = { workspace = true, features = ["std"] }
 bytes = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "color", "error-context", "help", "std", "suggestions", "usage"] }
 dotenvy = { workspace = true }
-ferroid-tonic-core = { version = "0.6.4", path = "../ferroid-tonic-core" }
+ferroid-tonic-core = { version = "0.6.5", path = "../ferroid-tonic-core" }
 futures = { workspace = true }
 mimalloc = { workspace = true }
 opentelemetry = { workspace = true, optional = true }

--- a/crates/ferroid/src/futures/snowflake.rs
+++ b/crates/ferroid/src/futures/snowflake.rs
@@ -1,7 +1,6 @@
 use super::SleepProvider;
 use crate::{IdGenStatus, Result, SnowflakeGenerator, SnowflakeId, TimeSource, ToU64};
 use core::{
-    fmt,
     future::Future,
     marker::PhantomData,
     pin::Pin,
@@ -23,7 +22,7 @@ where
     ID: SnowflakeId,
     T: TimeSource<ID::Ty>,
 {
-    type Err: fmt::Debug;
+    type Err;
 
     /// Returns a future that resolves to the next available Snowflake ID.
     ///

--- a/crates/ferroid/src/futures/ulid.rs
+++ b/crates/ferroid/src/futures/ulid.rs
@@ -1,7 +1,6 @@
 use super::SleepProvider;
 use crate::{IdGenStatus, RandSource, Result, TimeSource, ToU64, UlidGenerator, UlidId};
 use core::{
-    fmt,
     future::Future,
     marker::PhantomData,
     pin::Pin,
@@ -23,7 +22,7 @@ where
     T: TimeSource<ID::Ty>,
     R: RandSource<ID::Ty>,
 {
-    type Err: fmt::Debug;
+    type Err;
 
     /// Returns a future that resolves to the next available Snowflake ID.
     ///

--- a/crates/ferroid/src/runtime/smol_snowflake.rs
+++ b/crates/ferroid/src/runtime/smol_snowflake.rs
@@ -52,7 +52,6 @@ mod tests {
         AtomicSnowflakeGenerator, LockSnowflakeGenerator, MonotonicClock, Result, SleepProvider,
         SmolYield, SnowflakeGenerator, SnowflakeId, SnowflakeTwitterId, TimeSource,
     };
-    use core::fmt;
     use futures::future::try_join_all;
     use smol::Task;
     use std::collections::HashSet;
@@ -137,7 +136,7 @@ mod tests {
     ) -> Result<()>
     where
         G: SnowflakeGenerator<ID, T> + Send + Sync + 'static,
-        ID: SnowflakeId + fmt::Debug + Send + 'static,
+        ID: SnowflakeId + Send + 'static,
         T: TimeSource<ID::Ty> + Clone + Send,
         S: SleepProvider,
     {
@@ -173,7 +172,7 @@ mod tests {
     ) -> Result<()>
     where
         G: SnowflakeGenerator<ID, T> + Send + Sync + 'static,
-        ID: SnowflakeId + fmt::Debug + Send + 'static,
+        ID: SnowflakeId + Send + 'static,
         T: TimeSource<ID::Ty> + Clone + Send,
     {
         let clock = clock_factory();
@@ -203,7 +202,7 @@ mod tests {
 
     // Helper to validate uniqueness - shared between test approaches
     async fn validate_unique_snow_ids(
-        tasks: Vec<Task<Result<Vec<impl SnowflakeId + fmt::Debug>>>>,
+        tasks: Vec<Task<Result<Vec<impl SnowflakeId>>>>,
     ) -> Result<()> {
         let all_ids: Vec<_> = try_join_all(tasks).await?.into_iter().flatten().collect();
 

--- a/crates/ferroid/src/runtime/smol_ulid.rs
+++ b/crates/ferroid/src/runtime/smol_ulid.rs
@@ -1,5 +1,4 @@
 use crate::{RandSource, Result, SmolSleep, TimeSource, UlidGenerator, UlidId};
-use core::fmt;
 use core::future::Future;
 
 /// Extension trait for asynchronously generating ULIDs using the
@@ -16,7 +15,7 @@ where
     T: TimeSource<ID::Ty>,
     R: RandSource<ID::Ty>,
 {
-    type Err: fmt::Debug;
+    type Err;
     /// Returns a future that resolves to the next available Ulid using
     /// the [`SmolSleep`] provider.
     ///
@@ -55,7 +54,6 @@ mod tests {
         LockMonoUlidGenerator, MonotonicClock, RandSource, Result, SleepProvider, SmolYield,
         ThreadRandom, TimeSource, UlidGenerator, UlidId, ULID,
     };
-    use core::fmt;
     use futures::future::try_join_all;
     use smol::Task;
     use std::collections::HashSet;
@@ -111,7 +109,7 @@ mod tests {
     ) -> Result<()>
     where
         G: UlidGenerator<ID, T, R> + Send + Sync + 'static,
-        ID: UlidId + fmt::Debug + Send + 'static,
+        ID: UlidId + Send + 'static,
         T: TimeSource<ID::Ty> + Clone + Send,
         R: RandSource<ID::Ty> + Clone + Send,
         S: SleepProvider,
@@ -151,7 +149,7 @@ mod tests {
     where
         G: UlidGenerator<ID, T, R> + Send + Sync + 'static,
         G::Err: Send + Sync + 'static,
-        ID: UlidId + fmt::Debug + Send + 'static,
+        ID: UlidId + Send + 'static,
         T: TimeSource<ID::Ty> + Clone + Send,
         R: RandSource<ID::Ty> + Clone + Send,
     {

--- a/crates/ferroid/src/runtime/tokio_snowflake.rs
+++ b/crates/ferroid/src/runtime/tokio_snowflake.rs
@@ -1,5 +1,4 @@
 use crate::{Result, SnowflakeGenerator, SnowflakeId, TimeSource, TokioSleep};
-use core::fmt;
 use core::future::Future;
 
 /// Extension trait for asynchronously generating Snowflake IDs using the
@@ -15,7 +14,7 @@ where
     ID: SnowflakeId,
     T: TimeSource<ID::Ty>,
 {
-    type Err: fmt::Debug;
+    type Err;
     /// Returns a future that resolves to the next available Snowflake ID using
     /// the [`TokioSleep`] provider.
     ///
@@ -53,7 +52,6 @@ mod tests {
         AtomicSnowflakeGenerator, LockSnowflakeGenerator, MonotonicClock, Result, SleepProvider,
         SnowflakeGenerator, SnowflakeId, SnowflakeTwitterId, TimeSource, TokioYield,
     };
-    use core::fmt;
     use futures::future::try_join_all;
     use std::collections::HashSet;
     use std::vec::Vec;
@@ -125,7 +123,7 @@ mod tests {
     ) -> Result<()>
     where
         G: SnowflakeGenerator<ID, T> + Send + Sync + 'static,
-        ID: SnowflakeId + fmt::Debug + Send + 'static,
+        ID: SnowflakeId + Send + 'static,
         T: TimeSource<ID::Ty> + Clone + Send,
         S: SleepProvider,
     {
@@ -161,7 +159,7 @@ mod tests {
     ) -> Result<()>
     where
         G: SnowflakeGenerator<ID, T> + Send + Sync + 'static,
-        ID: SnowflakeId + fmt::Debug + Send + 'static,
+        ID: SnowflakeId + Send + 'static,
         T: TimeSource<ID::Ty> + Clone + Send,
     {
         let clock = clock_factory();
@@ -191,7 +189,7 @@ mod tests {
 
     // Helper to validate uniqueness - shared between test approaches
     async fn validate_unique_snow_ids(
-        tasks: Vec<tokio::task::JoinHandle<Result<Vec<impl SnowflakeId + fmt::Debug>>>>,
+        tasks: Vec<tokio::task::JoinHandle<Result<Vec<impl SnowflakeId>>>>,
     ) -> Result<()> {
         let all_ids: Vec<_> = try_join_all(tasks)
             .await

--- a/crates/ferroid/src/runtime/tokio_ulid.rs
+++ b/crates/ferroid/src/runtime/tokio_ulid.rs
@@ -1,5 +1,4 @@
 use crate::{RandSource, Result, TimeSource, TokioSleep, UlidGenerator, UlidId};
-use core::fmt;
 use core::future::Future;
 
 /// Extension trait for asynchronously generating ULIDs using the
@@ -16,7 +15,7 @@ where
     T: TimeSource<ID::Ty>,
     R: RandSource<ID::Ty>,
 {
-    type Err: fmt::Debug;
+    type Err;
 
     /// Returns a future that resolves to the next available ULID using
     /// the [`TokioSleep`] provider.
@@ -56,7 +55,6 @@ mod tests {
         LockMonoUlidGenerator, MonotonicClock, Result, SleepProvider, ThreadRandom, TimeSource,
         TokioYield, ULID,
     };
-    use core::fmt;
     use futures::future::try_join_all;
     use std::collections::HashSet;
     use std::vec::Vec;
@@ -144,7 +142,7 @@ mod tests {
     ) -> Result<()>
     where
         G: UlidGenerator<ID, T, R> + Send + Sync + 'static,
-        ID: UlidId + fmt::Debug + Send + 'static,
+        ID: UlidId + Send + 'static,
         T: TimeSource<ID::Ty> + Clone + Send,
         R: RandSource<ID::Ty> + Clone + Send,
     {


### PR DESCRIPTION
The bound is already included on the main `Id` interface and generator interfaces (`SnowflakeGenerator`, `UlidGenerator`) with the restriction, so we can remove it from futures interfaces.