### PR TITLE
Make `MonotonicClock` const-generic and expose time-source granularity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,9 +44,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -59,15 +59,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "async-channel"
@@ -112,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.3"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
 dependencies = [
  "async-task",
  "concurrent-queue",
@@ -310,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bitvec"
@@ -350,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byteorder"
@@ -416,9 +416,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -464,9 +464,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -513,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.56"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75ca66430e33a14957acc24c5077b503e7d374151b2b4b3a10c83b4ceb4be0e"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -534,9 +534,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.56"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793207c7fa6300a0608d1080b858e5fdbe713cdc1c8db9fb17777d8a13e63df0"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -546,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -558,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codepage"
@@ -573,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "concurrent-queue"
@@ -891,9 +891,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -928,9 +928,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -942,9 +942,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -952,15 +952,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -969,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-lite"
@@ -988,9 +988,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -999,28 +999,27 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-macro",
  "futures-sink",
  "futures-task",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1053,19 +1052,19 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
@@ -1232,13 +1231,12 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -1449,9 +1447,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1471,9 +1469,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libloading"
@@ -1497,19 +1495,18 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags",
  "libc",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1559,9 +1556,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mimalloc"
@@ -1623,9 +1620,9 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c70f219e21142367c70c0b30c6a9e3a14d55b4d12a204d897fbec83a0363f081"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
 ]
@@ -1658,10 +1655,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.21.3"
+name = "objc2-system-configuration"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1696,9 +1702,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
  "http",
  "opentelemetry",
@@ -1757,9 +1763,9 @@ dependencies = [
 
 [[package]]
 name = "owo-colors"
-version = "4.2.3"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 dependencies = [
  "supports-color",
 ]
@@ -1986,18 +1992,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2006,9 +2012,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -2018,9 +2024,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
 dependencies = [
  "atomic-waker",
  "fastrand",
@@ -2188,9 +2194,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
+checksum = "83c41efbf8f90ac44de7f3a868f0867851d261b56291732d0cbf7cceaaeb55a6"
 dependencies = [
  "bitflags",
  "memchr",
@@ -2208,9 +2214,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -2220,6 +2226,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -2244,7 +2256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
  "chacha20",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "rand_core 0.10.0",
 ]
 
@@ -2284,9 +2296,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2296,9 +2308,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2307,9 +2319,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "ring"
@@ -2333,9 +2345,9 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -2346,9 +2358,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "log",
  "once_cell",
@@ -2408,9 +2420,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -2429,9 +2441,9 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
-version = "3.5.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2442,9 +2454,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2601,12 +2613,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2649,9 +2661,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2696,12 +2708,12 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2778,9 +2790,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2793,9 +2805,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -2810,9 +2822,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2882,9 +2894,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.11+spec-1.1.0"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -2892,7 +2904,7 @@ dependencies = [
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -2906,24 +2918,24 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.0.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.0.7+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
 
 [[package]]
 name = "tonic"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a286e33f82f8a1ee2df63f4fa35c0becf4a85a0cb03091a15fd7bf0b402dc94a"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "axum",
@@ -2954,9 +2966,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27aac809edf60b741e2d7db6367214d078856b8a5bff0087e94ff330fb97b6fc"
+checksum = "1882ac3bf5ef12877d7ed57aad87e75154c11931c2ba7e6cde5e22d63522c734"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -2966,9 +2978,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-health"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dbde2c702c4be12b9b2f6f7e6c824a84a7b7be177070cada8ee575a581af359"
+checksum = "f4ff0636fef47afb3ec02818f5bceb4377b8abb9d6a386aeade18bd6212f8eb7"
 dependencies = [
  "prost",
  "tokio",
@@ -2979,9 +2991,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c55a2d6a14174563de34409c9f92ff981d006f56da9c6ecd40d9d4a31500b0"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
  "prost",
@@ -2990,9 +3002,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost-build"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4556786613791cfef4ed134aa670b61a85cfcacf71543ef33e8d801abae988f"
+checksum = "f3144df636917574672e93d0f56d7edec49f90305749c668df5101751bb8f95a"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -3006,9 +3018,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-reflection"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758112f988818866f38face806ebf8c8961ad2c087e2ba89ad30010ba5fd80c1"
+checksum = "aaf0685a51e6d02b502ba0764002e766b7f3042aed13d9234925b6ffbfa3fca7"
 dependencies = [
  "prost",
  "prost-types",
@@ -3020,9 +3032,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-web"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d84e41438a9108d27d348e2139ce58cc85bf411aeffb0493f96f992e72a970"
+checksum = "29453d84de05f4f1b573db22e6f9f6c95c189a6089a440c9a098aa9dea009299"
 dependencies = [
  "base64",
  "bytes",
@@ -3151,9 +3163,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "chrono",
  "matchers",
@@ -3203,9 +3215,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-normalization"
@@ -3272,11 +3284,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.20.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -3356,9 +3368,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3369,9 +3381,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3379,9 +3391,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3392,9 +3404,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -3435,9 +3447,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3455,11 +3467,13 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fae98cf96deed1b7572272dfc777713c249ae40aa1cf8862e091e8b745f5361"
+checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
 dependencies = [
+ "libc",
  "libredox",
+ "objc2-system-configuration",
  "wasite",
  "web-sys",
 ]
@@ -3502,7 +3516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
  "windows-core 0.57.0",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3514,7 +3528,7 @@ dependencies = [
  "windows-implement 0.57.0",
  "windows-interface 0.57.0",
  "windows-result 0.1.2",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3586,7 +3600,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3613,16 +3627,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3640,31 +3645,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -3674,22 +3662,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3698,22 +3674,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3722,22 +3686,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3746,28 +3698,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
+name = "winnow"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 
 [[package]]
 name = "wit-bindgen"
@@ -3903,18 +3849,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.37"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7456cf00f0685ad319c5b1693f291a650eaf345e941d082fc4e03df8a03996ac"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.37"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3983,9 +3929,9 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.18"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1966f8ac2c1f76987d69a74d0e0f929241c10e78136434e3be70ff7f58f64214"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,7 +817,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferroid"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "criterion",
  "crossbeam-utils",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "ferroid-tonic-core"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "ferroid",
  "prost",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "ferroid-tonic-server"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1835,7 +1835,7 @@ dependencies = [
 
 [[package]]
 name = "pg-ferroid"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "ferroid",
  "pgrx",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1431,9 +1431,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
@@ -2194,9 +2194,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c41efbf8f90ac44de7f3a868f0867851d261b56291732d0cbf7cceaaeb55a6"
+checksum = "14104c5a24d9bcf7eb2c24753e0f49fe14555d8bd565ea3d38e4b4303267259d"
 dependencies = [
  "bitflags",
  "memchr",
@@ -2394,9 +2394,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "1.0.2"
+version = "2.0.0"
 edition = "2024"
 rust-version = "1.85.1"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ documentation = "https://docs.rs/ferroid"
 anyhow = { version = "1.0", default-features = false }
 axum = { version = "0.8", default-features = false }
 bytes = { version = "1.11", default-features = false }
-clap = { version = "4.5", default-features = false }
+clap = { version = "4.6", default-features = false }
 criterion = { version = "0.7", default-features = false }
 crossbeam-utils = { version = "0.8", default-features = false }
 dotenvy = { version = "0.15", default-features = false }
@@ -50,7 +50,7 @@ serde = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", default-features = false }
 smol = { version = "2.0", default-features = false }
 thiserror = { version = "2.0", default-features = false }
-tokio = { version = "1.49", default-features = false }
+tokio = { version = "1.50", default-features = false }
 tokio-stream = { version = "0.1", default-features = false }
 tokio-util = { version = "0.7", default-features = false }
 tonic = { version = "0.14", default-features = false }

--- a/crates/ferroid-tonic-core/Cargo.toml
+++ b/crates/ferroid-tonic-core/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["ferroid", "grpc", "snowflake", "ulid", "monotonic"]
 publish = true
 
 [dependencies]
-ferroid = { version = "1.0.2", path = "../ferroid", features = ["std", "alloc", "snowflake", "basic"] }
+ferroid = { version = "2.0.0", path = "../ferroid", features = ["std", "alloc", "snowflake", "basic"] }
 prost = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tonic = { workspace = true, features = ["transport", "codegen"] }

--- a/crates/ferroid-tonic-server/Cargo.toml
+++ b/crates/ferroid-tonic-server/Cargo.toml
@@ -27,7 +27,7 @@ anyhow = { workspace = true, features = ["std"] }
 bytes = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "color", "error-context", "help", "std", "suggestions", "usage"] }
 dotenvy = { workspace = true }
-ferroid-tonic-core = { version = "1.0.2", path = "../ferroid-tonic-core" }
+ferroid-tonic-core = { version = "2.0.0", path = "../ferroid-tonic-core" }
 futures = { workspace = true }
 mimalloc = { workspace = true }
 opentelemetry = { workspace = true, optional = true }

--- a/crates/ferroid/README.md
+++ b/crates/ferroid/README.md
@@ -146,6 +146,10 @@ should override this depending on the ID specification. For example, Twitter IDs
 use `TWITTER_EPOCH`, which begins at **Thursday, November 4, 2010, 01:42:54.657
 UTC** (millisecond zero).
 
+`MonotonicClock<const N: u64 = 1>` returns timestamps in `N`-millisecond units.
+For example, `MonotonicClock<8>` advances in 8 ms quanta and generator
+timestamps/backoff values will use those units instead of literal milliseconds.
+
 ```rust
 use ferroid::{
       generator::BasicSnowflakeGenerator,
@@ -154,11 +158,11 @@ use ferroid::{
 };
 
 // Same as MonotonicClock::default();
-let unix_clock = MonotonicClock::with_epoch(UNIX_EPOCH);
+let unix_clock = MonotonicClock::<1>::with_epoch(UNIX_EPOCH);
 // Also the same as MonotonicClock::default();
-let unix_clock = MonotonicClock::with_epoch(MASTODON_EPOCH);
+let unix_clock = MonotonicClock::<1>::with_epoch(MASTODON_EPOCH);
 
-let twitter_clock = MonotonicClock::with_epoch(TWITTER_EPOCH);
+let twitter_clock = MonotonicClock::<1>::with_epoch(TWITTER_EPOCH);
 
 let mastodon_gen: BasicSnowflakeGenerator<SnowflakeMastodonId, _> = BasicSnowflakeGenerator::new(0, unix_clock);
 let twitter_gen: BasicSnowflakeGenerator<SnowflakeTwitterId, _> = BasicSnowflakeGenerator::new(0, twitter_clock);
@@ -169,8 +173,8 @@ let twitter_gen: BasicSnowflakeGenerator<SnowflakeTwitterId, _> = BasicSnowflake
 Calling `next_id()` will call the passed in backoff strategy closure if the
 underlying generator needs to yield. Please note that while this behavior is
 exposed to provide maximum flexibility, you must be generating enough IDs **per
-millisecond** to invoke this callback. You may spin, yield, or sleep depending
-on your environment:
+time-source tick** to invoke this callback. With `MonotonicClock<1>` that means
+per millisecond. You may spin, yield, or sleep depending on your environment:
 
 ```rust
 use ferroid::{
@@ -180,7 +184,7 @@ use ferroid::{
     time::{MonotonicClock, TWITTER_EPOCH},
 };
 
-let snow_gen = BasicSnowflakeGenerator::new(0, MonotonicClock::with_epoch(TWITTER_EPOCH));
+let snow_gen = BasicSnowflakeGenerator::new(0, MonotonicClock::<1>::with_epoch(TWITTER_EPOCH));
 let id: SnowflakeTwitterId = snow_gen.next_id(|yield_for: <SnowflakeTwitterId as Id>::Ty| {
     // Spin: lowest latency, but generally avoid. Or ...
     core::hint::spin_loop();
@@ -189,6 +193,7 @@ let id: SnowflakeTwitterId = snow_gen.next_id(|yield_for: <SnowflakeTwitterId as
     std::thread::yield_now();
 
     // Sleep for the suggested backoff: frees the core, but wakeup is imprecise.
+    // For coarser clocks, multiply by the clock's `GRANULARITY_MILLIS`.
     std::thread::sleep(std::time::Duration::from_millis(yield_for.to_u64()));
 
     // For use in runtimes such as `tokio` or `smol`, use the non-blocking async API (see below).
@@ -209,7 +214,8 @@ to avoid blocking behavior:
 
 These features extend the generator to yield cooperatively when it returns
 `Pending`, causing the current task to sleep for the specified `yield_for`
-duration (typically ~1ms). While this is fully non-blocking, it may oversleep
+duration scaled by the clock granularity (typically ~1ms with
+`MonotonicClock<1>`). While this is fully non-blocking, it may oversleep
 slightly due to OS or executor timing precision, potentially reducing peak
 throughput.
 
@@ -223,12 +229,12 @@ use ferroid::{
 };
 
 async fn run() -> Result<(), Error> {
-    let snow_gen = LockSnowflakeGenerator::new(0, MonotonicClock::with_epoch(MASTODON_EPOCH));
+    let snow_gen = LockSnowflakeGenerator::new(0, MonotonicClock::<1>::with_epoch(MASTODON_EPOCH));
     let id: SnowflakeMastodonId = snow_gen.try_next_id_async().await?;
     println!("Generated ID: {}", id);
 
     let ulid_gen = LockMonoUlidGenerator::new(
-        MonotonicClock::with_epoch(UNIX_EPOCH),
+        MonotonicClock::<1>::with_epoch(UNIX_EPOCH),
         ThreadRandom::default(),
     );
     let id: ULID = ulid_gen.try_next_id_async().await?;

--- a/crates/ferroid/README.md
+++ b/crates/ferroid/README.md
@@ -152,29 +152,32 @@ timestamps/backoff values will use those units instead of literal milliseconds.
 
 ```rust
 use ferroid::{
-      generator::BasicSnowflakeGenerator,
-      id::{SnowflakeTwitterId, SnowflakeMastodonId},
-      time::{MonotonicClock, TWITTER_EPOCH, MASTODON_EPOCH, UNIX_EPOCH}
+    generator::BasicSnowflakeGenerator,
+    id::{SnowflakeMastodonId, SnowflakeTwitterId},
+    time::{MASTODON_EPOCH, MonotonicClock, TWITTER_EPOCH, UNIX_EPOCH},
 };
 
 // Same as MonotonicClock::default();
 let unix_clock = MonotonicClock::<1>::with_epoch(UNIX_EPOCH);
-// Also the same as MonotonicClock::default();
-let unix_clock = MonotonicClock::<1>::with_epoch(MASTODON_EPOCH);
+// Also the same as MonotonicClock::default(), since MASTODON_EPOCH == UNIX_EPOCH.
+let mastodon_clock = MonotonicClock::<1>::with_epoch(MASTODON_EPOCH);
 
 let twitter_clock = MonotonicClock::<1>::with_epoch(TWITTER_EPOCH);
 
-let mastodon_gen: BasicSnowflakeGenerator<SnowflakeMastodonId, _> = BasicSnowflakeGenerator::new(0, unix_clock);
-let twitter_gen: BasicSnowflakeGenerator<SnowflakeTwitterId, _> = BasicSnowflakeGenerator::new(0, twitter_clock);
+let mastodon_gen: BasicSnowflakeGenerator<SnowflakeMastodonId, _> =
+    BasicSnowflakeGenerator::new(0, mastodon_clock);
+let twitter_gen: BasicSnowflakeGenerator<SnowflakeTwitterId, _> =
+    BasicSnowflakeGenerator::new(0, twitter_clock);
 ```
 
 #### Generating IDs
 
 Calling `next_id()` will call the passed in backoff strategy closure if the
 underlying generator needs to yield. Please note that while this behavior is
-exposed to provide maximum flexibility, you must be generating enough IDs **per
-time-source tick** to invoke this callback. With `MonotonicClock<1>` that means
-per millisecond. You may spin, yield, or sleep depending on your environment:
+exposed to provide maximum flexibility, you must be generating enough IDs
+within a single **time-source tick** to invoke this callback. With
+`MonotonicClock<1>`, that means within a single millisecond. You may spin,
+yield, or sleep depending on your environment:
 
 ```rust
 use ferroid::{
@@ -193,8 +196,11 @@ let id: SnowflakeTwitterId = snow_gen.next_id(|yield_for: <SnowflakeTwitterId as
     std::thread::yield_now();
 
     // Sleep for the suggested backoff: frees the core, but wakeup is imprecise.
-    // For coarser clocks, multiply by the clock's `GRANULARITY_MILLIS`.
-    std::thread::sleep(std::time::Duration::from_millis(yield_for.to_u64()));
+    std::thread::sleep(std::time::Duration::from_millis(
+        yield_for
+            .to_u64()
+            .saturating_mul(MonotonicClock::<1>::GRANULARITY_MILLIS),
+    ));
 
     // For use in runtimes such as `tokio` or `smol`, use the non-blocking async API (see below).
 });
@@ -477,9 +483,9 @@ in `no_std`.
 
 ### ULID
 
-This implementation respects monotonicity within the same millisecond in a
-single generator by incrementing the random portion of the ID and guarding
-against overflow.
+This implementation respects monotonicity within the same time-source tick
+(the same millisecond with `MonotonicClock<1>`) in a single generator by
+incrementing the random portion of the ID and guarding against overflow.
 
 - If the clock **advances**: generate new random → `Poll::Ready`
 - If the clock is **unchanged**: increment random → `Poll::Ready`
@@ -493,6 +499,9 @@ against overflow.
 When generating time-sortable IDs that use random bits, it's important to
 estimate the probability of collisions (i.e., two IDs being the same within the
 same millisecond), given your ID layout and system throughput.
+
+The calculations below assume millisecond timestamps. If you use a coarser
+custom clock, substitute your time-source tick size accordingly.
 
 #### Non-monotonic (always-random) collision probability
 

--- a/crates/ferroid/src/futures/runtime/smol/ulid.rs
+++ b/crates/ferroid/src/futures/runtime/smol/ulid.rs
@@ -157,7 +157,7 @@ mod tests {
         });
     }
     #[test]
-    fn generates_many_unique_ids_basic_smol_convience() {
+    fn generates_many_unique_ids_basic_smol_convenience() {
         smol::block_on(async {
             test_many_ulid_unique_ids_convenience::<ULID, _, _, _>(
                 LockMonoUlidGenerator::new,

--- a/crates/ferroid/src/futures/runtime/tokio/ulid.rs
+++ b/crates/ferroid/src/futures/runtime/tokio/ulid.rs
@@ -145,7 +145,7 @@ mod tests {
         Ok(())
     }
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-    async fn generates_many_unique_ids_basic_convience() -> Result<()> {
+    async fn generates_many_unique_ids_basic_convenience() -> Result<()> {
         test_many_ulid_unique_ids_convenience::<ULID, _, _, _>(
             LockMonoUlidGenerator::new,
             MonotonicClock::default,

--- a/crates/ferroid/src/futures/snowflake.rs
+++ b/crates/ferroid/src/futures/snowflake.rs
@@ -75,9 +75,102 @@ where
         loop {
             let dur = match self.try_poll_id()? {
                 Poll::Ready { id } => break Ok(id),
-                Poll::Pending { yield_for } => Duration::from_millis(yield_for.to_u64()),
+                Poll::Pending { yield_for } => {
+                    Duration::from_millis(yield_for.to_u64().saturating_mul(T::GRANULARITY_MILLIS))
+                }
             };
             S::sleep_for(dur).await;
         }
+    }
+}
+
+#[cfg(all(test, feature = "lock"))]
+mod tests {
+    use core::{
+        pin::pin,
+        task::{Context, Poll as TaskPoll, RawWaker, RawWakerVTable, Waker},
+    };
+    use std::sync::{
+        Mutex,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use super::*;
+    use crate::{generator::LockSnowflakeGenerator, id::SnowflakeTwitterId};
+
+    static LAST_SLEEP: Mutex<Option<Duration>> = Mutex::new(None);
+
+    struct RecordingSleep;
+
+    impl SleepProvider for RecordingSleep {
+        fn sleep_for(dur: Duration) -> impl Future<Output = ()> + Send {
+            async move {
+                *LAST_SLEEP.lock().unwrap() = Some(dur);
+            }
+        }
+    }
+
+    #[derive(Default)]
+    struct CoarseStepTime {
+        reads: AtomicUsize,
+    }
+
+    impl TimeSource<u64> for CoarseStepTime {
+        const GRANULARITY_MILLIS: u64 = 8;
+
+        fn current_millis(&self) -> u64 {
+            self.reads.fetch_add(1, Ordering::Relaxed) as u64
+        }
+    }
+
+    fn block_on<F: Future>(future: F) -> F::Output {
+        fn raw_waker() -> RawWaker {
+            fn clone(_: *const ()) -> RawWaker {
+                raw_waker()
+            }
+            fn wake(_: *const ()) {}
+            fn wake_by_ref(_: *const ()) {}
+            fn drop(_: *const ()) {}
+
+            RawWaker::new(
+                core::ptr::null(),
+                &RawWakerVTable::new(clone, wake, wake_by_ref, drop),
+            )
+        }
+
+        let waker = unsafe { Waker::from_raw(raw_waker()) };
+        let mut context = Context::from_waker(&waker);
+        let mut future = pin!(future);
+
+        loop {
+            match future.as_mut().poll(&mut context) {
+                TaskPoll::Ready(value) => break value,
+                TaskPoll::Pending => core::hint::spin_loop(),
+            }
+        }
+    }
+
+    #[test]
+    fn async_backoff_uses_time_source_granularity() {
+        *LAST_SLEEP.lock().unwrap() = None;
+
+        let generator: LockSnowflakeGenerator<SnowflakeTwitterId, _> =
+            LockSnowflakeGenerator::from_components(
+                0,
+                0,
+                SnowflakeTwitterId::max_sequence(),
+                CoarseStepTime::default(),
+            );
+
+        let id = block_on(
+            <LockSnowflakeGenerator<SnowflakeTwitterId, _> as SnowflakeGeneratorAsyncExt<
+                SnowflakeTwitterId,
+                _,
+            >>::try_next_id_async::<RecordingSleep>(&generator),
+        )
+        .unwrap();
+
+        assert_eq!(*LAST_SLEEP.lock().unwrap(), Some(Duration::from_millis(8)));
+        assert_eq!(id.timestamp(), 1);
     }
 }

--- a/crates/ferroid/src/futures/ulid.rs
+++ b/crates/ferroid/src/futures/ulid.rs
@@ -77,9 +77,111 @@ where
         loop {
             let dur = match self.try_poll_id()? {
                 Poll::Ready { id } => break Ok(id),
-                Poll::Pending { yield_for } => Duration::from_millis(yield_for.to_u64()),
+                Poll::Pending { yield_for } => {
+                    Duration::from_millis(yield_for.to_u64().saturating_mul(T::GRANULARITY_MILLIS))
+                }
             };
             S::sleep_for(dur).await;
         }
+    }
+}
+
+#[cfg(all(test, feature = "lock"))]
+mod tests {
+    use core::{
+        pin::pin,
+        task::{Context, Poll as TaskPoll, RawWaker, RawWakerVTable, Waker},
+    };
+    use std::sync::{
+        Mutex,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use super::*;
+    use crate::{generator::LockMonoUlidGenerator, id::ULID};
+
+    static LAST_SLEEP: Mutex<Option<Duration>> = Mutex::new(None);
+
+    struct RecordingSleep;
+
+    impl SleepProvider for RecordingSleep {
+        fn sleep_for(dur: Duration) -> impl Future<Output = ()> + Send {
+            async move {
+                *LAST_SLEEP.lock().unwrap() = Some(dur);
+            }
+        }
+    }
+
+    #[derive(Default)]
+    struct CoarseStepTime {
+        reads: AtomicUsize,
+    }
+
+    impl TimeSource<u128> for CoarseStepTime {
+        const GRANULARITY_MILLIS: u64 = 8;
+
+        fn current_millis(&self) -> u128 {
+            self.reads.fetch_add(1, Ordering::Relaxed) as u128
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    struct ZeroRand;
+
+    impl RandSource<u128> for ZeroRand {
+        fn rand(&self) -> u128 {
+            0
+        }
+    }
+
+    fn block_on<F: Future>(future: F) -> F::Output {
+        fn raw_waker() -> RawWaker {
+            fn clone(_: *const ()) -> RawWaker {
+                raw_waker()
+            }
+            fn wake(_: *const ()) {}
+            fn wake_by_ref(_: *const ()) {}
+            fn drop(_: *const ()) {}
+
+            RawWaker::new(
+                core::ptr::null(),
+                &RawWakerVTable::new(clone, wake, wake_by_ref, drop),
+            )
+        }
+
+        let waker = unsafe { Waker::from_raw(raw_waker()) };
+        let mut context = Context::from_waker(&waker);
+        let mut future = pin!(future);
+
+        loop {
+            match future.as_mut().poll(&mut context) {
+                TaskPoll::Ready(value) => break value,
+                TaskPoll::Pending => core::hint::spin_loop(),
+            }
+        }
+    }
+
+    #[test]
+    fn async_backoff_uses_time_source_granularity() {
+        *LAST_SLEEP.lock().unwrap() = None;
+
+        let generator: LockMonoUlidGenerator<ULID, _, _> = LockMonoUlidGenerator::from_components(
+            0,
+            ULID::max_random(),
+            CoarseStepTime::default(),
+            ZeroRand,
+        );
+
+        let id = block_on(
+            <LockMonoUlidGenerator<ULID, _, _> as UlidGeneratorAsyncExt<
+                ULID,
+                _,
+                _,
+            >>::try_next_id_async::<RecordingSleep>(&generator),
+        )
+        .unwrap();
+
+        assert_eq!(*LAST_SLEEP.lock().unwrap(), Some(Duration::from_millis(8)));
+        assert_eq!(id.timestamp(), 1);
     }
 }

--- a/crates/ferroid/src/generator/snowflake/atomic.rs
+++ b/crates/ferroid/src/generator/snowflake/atomic.rs
@@ -80,7 +80,8 @@ where
     ///     time::{MonotonicClock, TWITTER_EPOCH},
     /// };
     ///
-    /// let generator = AtomicSnowflakeGenerator::new(0, MonotonicClock::with_epoch(TWITTER_EPOCH));
+    /// let generator =
+    ///     AtomicSnowflakeGenerator::new(0, MonotonicClock::<1>::with_epoch(TWITTER_EPOCH));
     ///
     /// let id: SnowflakeTwitterId = generator.next_id(|_| std::thread::yield_now());
     /// ```
@@ -98,7 +99,7 @@ where
     /// point of the generator manually.
     ///
     /// # Parameters
-    /// - `timestamp`: The initial timestamp component (usually in milliseconds)
+    /// - `timestamp`: The initial timestamp component (usually in time-source units)
     /// - `machine_id`: The machine or worker identifier
     /// - `sequence`: The initial sequence number
     /// - `time`: A [`TimeSource`] implementation used to fetch the current time
@@ -166,7 +167,8 @@ where
     ///     time::{MonotonicClock, TWITTER_EPOCH},
     /// };
     ///
-    /// let generator = AtomicSnowflakeGenerator::new(0, MonotonicClock::with_epoch(TWITTER_EPOCH));
+    /// let generator =
+    ///     AtomicSnowflakeGenerator::new(0, MonotonicClock::<1>::with_epoch(TWITTER_EPOCH));
     ///
     /// let id: SnowflakeTwitterId = loop {
     ///     match generator.poll_id() {

--- a/crates/ferroid/src/generator/snowflake/basic.rs
+++ b/crates/ferroid/src/generator/snowflake/basic.rs
@@ -70,7 +70,8 @@ where
     ///     time::{MonotonicClock, TWITTER_EPOCH},
     /// };
     ///
-    /// let generator = BasicSnowflakeGenerator::new(0, MonotonicClock::with_epoch(TWITTER_EPOCH));
+    /// let generator =
+    ///     BasicSnowflakeGenerator::new(0, MonotonicClock::<1>::with_epoch(TWITTER_EPOCH));
     ///
     /// let id: SnowflakeTwitterId = generator.next_id(|_| std::thread::yield_now());
     /// ```
@@ -88,7 +89,7 @@ where
     /// point of the generator manually.
     ///
     /// # Parameters
-    /// - `timestamp`: The initial timestamp component (usually in milliseconds)
+    /// - `timestamp`: The initial timestamp component (usually in time-source units)
     /// - `machine_id`: The machine or worker identifier
     /// - `sequence`: The initial sequence number
     /// - `time`: A [`TimeSource`] implementation used to fetch the current time
@@ -152,7 +153,8 @@ where
     ///     time::{MonotonicClock, TWITTER_EPOCH},
     /// };
     ///
-    /// let generator = BasicSnowflakeGenerator::new(0, MonotonicClock::with_epoch(TWITTER_EPOCH));
+    /// let generator =
+    ///     BasicSnowflakeGenerator::new(0, MonotonicClock::<1>::with_epoch(TWITTER_EPOCH));
     ///
     /// let id: SnowflakeTwitterId = loop {
     ///     match generator.poll_id() {

--- a/crates/ferroid/src/generator/snowflake/basic.rs
+++ b/crates/ferroid/src/generator/snowflake/basic.rs
@@ -47,8 +47,8 @@ where
     ///
     /// This constructor sets the initial timestamp and sequence to zero, and
     /// uses the provided `time` to fetch the current time during ID generation.
-    /// It is the recommended way to create a new atomic generator for typical
-    /// use cases.
+    /// It is the recommended way to create a new generator for typical use
+    /// cases.
     ///
     /// # Parameters
     ///

--- a/crates/ferroid/src/generator/snowflake/interface.rs
+++ b/crates/ferroid/src/generator/snowflake/interface.rs
@@ -24,7 +24,8 @@ where
     /// [`SnowflakeGenerator::try_next_id`]. The returned [`Poll`] contains
     /// either:
     /// - the newly generated ID, or
-    /// - a duration to yield/sleep if the timestamp sequence is exhausted.
+    /// - a duration to yield/sleep if the generator must wait for the time
+    ///   source to advance.
     fn next_id(&self, f: impl FnMut(ID::Ty)) -> ID
     where
         Self::Err: Into<core::convert::Infallible>,
@@ -43,7 +44,8 @@ where
     ///
     /// The returned [`Poll`] contains either:
     /// - the newly generated ID, or
-    /// - a duration to yield/sleep if the timestamp sequence is exhausted.
+    /// - a duration to yield/sleep if the generator must wait for the time
+    ///   source to advance.
     ///
     /// # Errors
     ///
@@ -57,7 +59,8 @@ where
     /// [`SnowflakeGenerator::try_poll_id`]. The returned [`Poll`] contains
     /// either:
     /// - the newly generated ID, or
-    /// - a duration to yield/sleep if the timestamp sequence is exhausted.
+    /// - a duration to yield/sleep if the generator must wait for the time
+    ///   source to advance.
     fn poll_id(&self) -> Poll<ID>
     where
         Self::Err: Into<core::convert::Infallible>,
@@ -76,7 +79,8 @@ where
     ///
     /// The returned [`Poll`] contains either:
     /// - the newly generated ID, or
-    /// - a duration to yield/sleep if the timestamp sequence is exhausted.
+    /// - a duration to yield/sleep if the generator must wait for the time
+    ///   source to advance.
     ///
     /// # Errors
     ///

--- a/crates/ferroid/src/generator/snowflake/lock.rs
+++ b/crates/ferroid/src/generator/snowflake/lock.rs
@@ -53,8 +53,8 @@ where
     ///
     /// This constructor sets the initial timestamp and sequence to zero, and
     /// uses the provided `time` to fetch the current time during ID generation.
-    /// It is the recommended way to create a new atomic generator for typical
-    /// use cases.
+    /// It is the recommended way to create a new lock-based generator for
+    /// typical use cases.
     ///
     /// # Parameters
     ///
@@ -224,7 +224,7 @@ where
         }
     }
 
-    /// Attempts to generate a new ULID with fallible error handling.
+    /// Attempts to generate a new Snowflake ID with fallible error handling.
     ///
     /// This method attempts to generate the next ID based on the current time
     /// and internal state. If successful, it returns [`Poll::Ready`] with a
@@ -234,8 +234,8 @@ where
     ///
     /// # Returns
     /// - `Ok(Poll::Ready { id })`: A new ID is available
-    /// - `Ok(Poll::Pending { yield_for })`: The time to wait in time-source units
-    ///   before trying again
+    /// - `Ok(Poll::Pending { yield_for })`: The time to wait in time-source
+    ///   units before trying again
     /// - `Err(e)`: the lock was poisoned
     ///
     /// # Example
@@ -254,7 +254,11 @@ where
     ///     match generator.try_poll_id() {
     ///         Ok(Poll::Ready { id }) => break id,
     ///         Ok(Poll::Pending { yield_for }) => {
-    ///             std::thread::sleep(core::time::Duration::from_millis(yield_for.to_u64()));
+    ///             std::thread::sleep(core::time::Duration::from_millis(
+    ///                 yield_for
+    ///                     .to_u64()
+    ///                     .saturating_mul(MonotonicClock::<1>::GRANULARITY_MILLIS),
+    ///             ));
     ///         }
     ///         Err(e) => panic!("Generator error: {}", e),
     ///     }

--- a/crates/ferroid/src/generator/snowflake/lock.rs
+++ b/crates/ferroid/src/generator/snowflake/lock.rs
@@ -77,7 +77,8 @@ where
     ///         time::{MonotonicClock, TWITTER_EPOCH},
     ///     };
     ///
-    ///     let generator = LockSnowflakeGenerator::new(0, MonotonicClock::with_epoch(TWITTER_EPOCH));
+    ///     let generator =
+    ///         LockSnowflakeGenerator::new(0, MonotonicClock::<1>::with_epoch(TWITTER_EPOCH));
     ///
     ///     let id: SnowflakeTwitterId = generator.next_id(|_| std::thread::yield_now());
     /// }
@@ -96,7 +97,7 @@ where
     /// point of the generator manually.
     ///
     /// # Parameters
-    /// - `timestamp`: The initial timestamp component (usually in milliseconds)
+    /// - `timestamp`: The initial timestamp component (usually in time-source units)
     /// - `machine_id`: The machine or worker identifier
     /// - `sequence`: The initial sequence number
     /// - `time`: A [`TimeSource`] implementation used to fetch the current time
@@ -198,7 +199,8 @@ where
     ///     time::{MonotonicClock, TWITTER_EPOCH},
     /// };
     ///
-    /// let generator = LockSnowflakeGenerator::new(0, MonotonicClock::with_epoch(TWITTER_EPOCH));
+    /// let generator =
+    ///     LockSnowflakeGenerator::new(0, MonotonicClock::<1>::with_epoch(TWITTER_EPOCH));
     ///
     /// let id: SnowflakeTwitterId = loop {
     ///     match generator.poll_id() {
@@ -232,7 +234,7 @@ where
     ///
     /// # Returns
     /// - `Ok(Poll::Ready { id })`: A new ID is available
-    /// - `Ok(Poll::Pending { yield_for })`: The time to wait (in milliseconds)
+    /// - `Ok(Poll::Pending { yield_for })`: The time to wait in time-source units
     ///   before trying again
     /// - `Err(e)`: the lock was poisoned
     ///
@@ -244,7 +246,8 @@ where
     ///     time::{MonotonicClock, TWITTER_EPOCH},
     /// };
     ///
-    /// let generator = LockSnowflakeGenerator::new(0, MonotonicClock::with_epoch(TWITTER_EPOCH));
+    /// let generator =
+    ///     LockSnowflakeGenerator::new(0, MonotonicClock::<1>::with_epoch(TWITTER_EPOCH));
     ///
     /// // Attempt to generate a new ID
     /// let id: SnowflakeTwitterId = loop {

--- a/crates/ferroid/src/generator/snowflake/tests.rs
+++ b/crates/ferroid/src/generator/snowflake/tests.rs
@@ -10,7 +10,7 @@ use std::{
 use crate::{
     generator::{BasicSnowflakeGenerator, LockSnowflakeGenerator, Poll, SnowflakeGenerator},
     id::{Id, SnowflakeId, SnowflakeTwitterId, ToU64},
-    time::{MonotonicClock, TimeSource},
+    time::{MonotonicClock, TimeSource, UNIX_EPOCH},
 };
 
 struct MockTime {
@@ -316,6 +316,14 @@ fn atomic_generator_rollover_test() {
 #[test]
 fn basic_generator_monotonic_clock_sequence_increments() {
     let clock = MonotonicClock::default();
+    let generator: BasicSnowflakeGenerator<SnowflakeTwitterId, _> =
+        BasicSnowflakeGenerator::new(1, clock);
+    run_generator_monotonic(&generator);
+}
+
+#[test]
+fn basic_generator_quantized_monotonic_clock_sequence_increments() {
+    let clock = MonotonicClock::<8>::with_epoch(UNIX_EPOCH);
     let generator: BasicSnowflakeGenerator<SnowflakeTwitterId, _> =
         BasicSnowflakeGenerator::new(1, clock);
     run_generator_monotonic(&generator);

--- a/crates/ferroid/src/generator/status.rs
+++ b/crates/ferroid/src/generator/status.rs
@@ -44,10 +44,10 @@ pub enum Poll<T: Id> {
     },
     /// The generator is not ready to produce a new ID yet.
     ///
-    /// Wait for the specified number of milliseconds (`yield_for`) before
+    /// Wait for the specified number of time-source units (`yield_for`) before
     /// trying again.
     Pending {
-        /// Milliseconds to wait before the next attempt.
+        /// Time-source units to wait before the next attempt.
         yield_for: T::Ty,
     },
 }

--- a/crates/ferroid/src/generator/status.rs
+++ b/crates/ferroid/src/generator/status.rs
@@ -1,12 +1,14 @@
 use crate::id::Id;
 
-/// Represents the result of attempting to generate a new Snowflake ID.
+/// Represents the result of attempting to generate a new ID.
 ///
-/// This type models the outcome of `SnowflakeGenerator::try_next_id()`:
+/// This type models the outcome of generator polling APIs such as
+/// [`crate::generator::SnowflakeGenerator::try_poll_id`] and
+/// [`crate::generator::UlidGenerator::try_poll_id`]:
 ///
 /// - [`Poll::Ready`] indicates a new ID was successfully generated.
 /// - [`Poll::Pending`] means the generator is throttled and cannot produce a
-///   new ID until the clock advances past `yield_for`.
+///   new ID until the time source advances past `yield_for`.
 ///
 /// This allows non-blocking generation loops and clean backoff strategies.
 ///
@@ -37,9 +39,9 @@ use crate::id::Id;
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Poll<T: Id> {
-    /// A new Snowflake ID was successfully generated.
+    /// A new ID was successfully generated.
     Ready {
-        /// The generated Snowflake ID.
+        /// The generated ID.
         id: T,
     },
     /// The generator is not ready to produce a new ID yet.

--- a/crates/ferroid/src/generator/ulid/atomic_mono.rs
+++ b/crates/ferroid/src/generator/ulid/atomic_mono.rs
@@ -20,7 +20,7 @@ use crate::{
 /// ## Features
 /// - ✅ Thread-safe
 /// - ✅ Probabilistically unique (no coordination required)
-/// - ✅ Time-ordered (monotonically increasing per millisecond)
+/// - ✅ Time-ordered (monotonically increasing per time-source tick)
 ///
 /// ## Caveats
 /// This implementation uses an [`AtomicU128`] internally, so it only supports
@@ -30,7 +30,7 @@ use crate::{
 /// ## Recommended When
 /// - You're in a multi-threaded environment
 /// - You need require monotonically increasing IDs (ID generated within the
-///   same millisecond increment a sequence counter)
+///   same time-source tick increment a sequence counter)
 ///
 /// ## See Also
 /// - [`BasicUlidGenerator`]
@@ -100,7 +100,7 @@ where
     /// point of the generator manually.
     ///
     /// # Parameters
-    /// - `timestamp`: The initial timestamp component (usually in milliseconds)
+    /// - `timestamp`: The initial timestamp component (usually in time-source units)
     /// - `machine_id`: The machine or worker identifier
     /// - `sequence`: The initial sequence number
     /// - `time`: A [`TimeSource`] implementation used to fetch the current time

--- a/crates/ferroid/src/generator/ulid/atomic_mono.rs
+++ b/crates/ferroid/src/generator/ulid/atomic_mono.rs
@@ -11,7 +11,7 @@ use crate::{
     time::TimeSource,
 };
 
-/// A lock-free *monotonic* ULID-style ID generator suitable for single-threaded
+/// A lock-free *monotonic* ULID-style ID generator suitable for multi-threaded
 /// environments.
 ///
 /// This generator stores the ULID in an [`AtomicU128`], allowing safe shared
@@ -29,8 +29,8 @@ use crate::{
 ///
 /// ## Recommended When
 /// - You're in a multi-threaded environment
-/// - You need require monotonically increasing IDs (ID generated within the
-///   same time-source tick increment a sequence counter)
+/// - You need monotonically increasing IDs (IDs generated within the same
+///   time-source tick increment the random component)
 ///
 /// ## See Also
 /// - [`BasicUlidGenerator`]
@@ -100,10 +100,11 @@ where
     /// point of the generator manually.
     ///
     /// # Parameters
-    /// - `timestamp`: The initial timestamp component (usually in time-source units)
-    /// - `machine_id`: The machine or worker identifier
-    /// - `sequence`: The initial sequence number
+    /// - `timestamp`: The initial timestamp component (usually in
+    ///   time-source units)
+    /// - `random`: The initial random component
     /// - `time`: A [`TimeSource`] implementation used to fetch the current time
+    /// - `rng`: A [`RandSource`] used to generate future random bits
     ///
     /// # Returns
     /// A new generator instance preloaded with the given state.
@@ -155,8 +156,9 @@ where
     /// Attempts to generate a new ULID.
     ///
     /// Returns a new, time-ordered, unique ID if generation succeeds. If the
-    /// generator is temporarily exhausted (e.g., the sequence is full and the
-    /// time has not advanced, or CAS fails), it returns [`Poll::Pending`].
+    /// generator is temporarily exhausted (e.g., the random component is
+    /// exhausted and the time has not advanced, or CAS fails), it returns
+    /// [`Poll::Pending`].
     ///
     /// # Example
     /// ```

--- a/crates/ferroid/src/generator/ulid/basic.rs
+++ b/crates/ferroid/src/generator/ulid/basic.rs
@@ -19,11 +19,11 @@ use crate::{
 /// ## Features
 /// - ✅ Thread-safe
 /// - ✅ Probabilistically unique (no coordination required)
-/// - ✅ Time-ordered (not monotonically increasing, random per millisecond)
+/// - ✅ Time-ordered (not monotonically increasing, random per time-source tick)
 ///
 /// ## Recommended When
 /// - You're in a single or multi-threaded environment
-/// - You require purely random IDs (even within the same millisecond)
+/// - You require purely random IDs (even within the same time-source tick)
 ///
 /// ## See Also
 /// - [`BasicMonoUlidGenerator`]

--- a/crates/ferroid/src/generator/ulid/basic.rs
+++ b/crates/ferroid/src/generator/ulid/basic.rs
@@ -14,7 +14,7 @@ use crate::{
 /// environments.
 ///
 /// This generator is lightweight and fast, but has a higher collision
-/// probabiliy than it's monotonic counterpart.
+/// probability than the monotonic variants.
 ///
 /// ## Features
 /// - ✅ Thread-safe

--- a/crates/ferroid/src/generator/ulid/basic_mono.rs
+++ b/crates/ferroid/src/generator/ulid/basic_mono.rs
@@ -22,8 +22,8 @@ use crate::{
 ///
 /// ## Recommended When
 /// - You're in a single-threaded environment (no shared access)
-/// - You need require monotonically increasing IDs (ID generated within the
-///   same time-source tick increment a sequence counter)
+/// - You need monotonically increasing IDs (IDs generated within the same
+///   time-source tick increment the random component)
 ///
 /// ## See Also
 /// - [`BasicUlidGenerator`]
@@ -88,10 +88,11 @@ where
     /// point of the generator manually.
     ///
     /// # Parameters
-    /// - `timestamp`: The initial timestamp component (usually in time-source units)
-    /// - `machine_id`: The machine or worker identifier
-    /// - `sequence`: The initial sequence number
+    /// - `timestamp`: The initial timestamp component (usually in
+    ///   time-source units)
+    /// - `random`: The initial random component
     /// - `time`: A [`TimeSource`] implementation used to fetch the current time
+    /// - `rng`: A [`RandSource`] used to generate future random bits
     ///
     /// # Returns
     /// A new generator instance preloaded with the given state.
@@ -138,8 +139,8 @@ where
     /// Generates a new ULID.
     ///
     /// Returns a new, time-ordered, unique ID if generation succeeds. If the
-    /// generator is temporarily exhausted (e.g., the sequence is full and the
-    /// time has not advanced), it returns [`Poll::Pending`].
+    /// generator is temporarily exhausted (e.g., the random component is
+    /// exhausted and the time has not advanced), it returns [`Poll::Pending`].
     ///
     /// # Example
     /// ```

--- a/crates/ferroid/src/generator/ulid/basic_mono.rs
+++ b/crates/ferroid/src/generator/ulid/basic_mono.rs
@@ -18,12 +18,12 @@ use crate::{
 /// ## Features
 /// - ❌ Not thread-safe
 /// - ✅ Probabilistically unique (no coordination required)
-/// - ✅ Time-ordered (monotonically increasing per millisecond)
+/// - ✅ Time-ordered (monotonically increasing per time-source tick)
 ///
 /// ## Recommended When
 /// - You're in a single-threaded environment (no shared access)
 /// - You need require monotonically increasing IDs (ID generated within the
-///   same millisecond increment a sequence counter)
+///   same time-source tick increment a sequence counter)
 ///
 /// ## See Also
 /// - [`BasicUlidGenerator`]
@@ -88,7 +88,7 @@ where
     /// point of the generator manually.
     ///
     /// # Parameters
-    /// - `timestamp`: The initial timestamp component (usually in milliseconds)
+    /// - `timestamp`: The initial timestamp component (usually in time-source units)
     /// - `machine_id`: The machine or worker identifier
     /// - `sequence`: The initial sequence number
     /// - `time`: A [`TimeSource`] implementation used to fetch the current time

--- a/crates/ferroid/src/generator/ulid/interface.rs
+++ b/crates/ferroid/src/generator/ulid/interface.rs
@@ -25,7 +25,8 @@ where
     /// This is the infallible counterpart to [`UlidGenerator::try_next_id`].
     /// The returned [`Poll`] contains either:
     /// - the newly generated ID, or
-    /// - a duration to yield/sleep if the timestamp sequence is exhausted.
+    /// - a duration to yield/sleep if the generator must wait for the time
+    ///   source to advance.
     fn next_id(&self, f: impl FnMut(ID::Ty)) -> ID
     where
         Self::Err: Into<core::convert::Infallible>,
@@ -44,7 +45,8 @@ where
     ///
     /// The returned [`Poll`] contains either:
     /// - the newly generated ID, or
-    /// - a duration to yield/sleep if the timestamp sequence is exhausted.
+    /// - a duration to yield/sleep if the generator must wait for the time
+    ///   source to advance.
     ///
     /// # Errors
     ///
@@ -57,7 +59,8 @@ where
     /// This is the infallible counterpart to [`UlidGenerator::try_poll_id`].
     /// The returned [`Poll`] contains either:
     /// - the newly generated ID, or
-    /// - a duration to yield/sleep if the timestamp sequence is exhausted.
+    /// - a duration to yield/sleep if the generator must wait for the time
+    ///   source to advance.
     fn poll_id(&self) -> Poll<ID>
     where
         Self::Err: Into<core::convert::Infallible>,
@@ -76,7 +79,8 @@ where
     ///
     /// The returned [`Poll`] contains either:
     /// - the newly generated ID, or
-    /// - a duration to yield/sleep if the timestamp sequence is exhausted.
+    /// - a duration to yield/sleep if the generator must wait for the time
+    ///   source to advance.
     ///
     /// # Errors
     ///

--- a/crates/ferroid/src/generator/ulid/lock_mono.rs
+++ b/crates/ferroid/src/generator/ulid/lock_mono.rs
@@ -14,7 +14,7 @@ use crate::{
 /// A lock-based *monotonic* ULID-style ID generator suitable for multi-threaded
 /// environments.
 ///
-/// This generator wraps the Ulid state in an [`Arc<Mutex<_>>`], allowing safe
+/// This generator wraps the ULID state in an [`Arc<Mutex<_>>`], allowing safe
 /// shared use across threads.
 ///
 /// ## Features
@@ -24,8 +24,8 @@ use crate::{
 ///
 /// ## Recommended When
 /// - You're in a multi-threaded environment
-/// - You need require monotonically increasing IDs (ID generated within the
-///   same time-source tick increment a sequence counter)
+/// - You need monotonically increasing IDs (IDs generated within the same
+///   time-source tick increment the random component)
 /// - Your target doesn't support atomics.
 ///
 /// ## See Also
@@ -96,10 +96,11 @@ where
     /// point of the generator manually.
     ///
     /// # Parameters
-    /// - `timestamp`: The initial timestamp component (usually in time-source units)
-    /// - `machine_id`: The machine or worker identifier
-    /// - `sequence`: The initial sequence number
+    /// - `timestamp`: The initial timestamp component (usually in
+    ///   time-source units)
+    /// - `random`: The initial random component
     /// - `time`: A [`TimeSource`] implementation used to fetch the current time
+    /// - `rng`: A [`RandSource`] used to generate future random bits
     ///
     /// # Returns
     /// A new generator instance preloaded with the given state.
@@ -185,8 +186,8 @@ where
     /// Generates a new ULID.
     ///
     /// Returns a new, time-ordered, unique ID if generation succeeds. If the
-    /// generator is temporarily exhausted (e.g., the sequence is full and the
-    /// time has not advanced), it returns [`Poll::Pending`].
+    /// generator is temporarily exhausted (e.g., the random component is
+    /// exhausted and the time has not advanced), it returns [`Poll::Pending`].
     ///
     /// # Example
     /// ```
@@ -223,13 +224,16 @@ where
 
     /// Attempts to generate a new ULID with fallible error handling.
     ///
-    /// Combines the current timestamp with a freshly generated random value to
-    /// produce a unique identifier. Returns [`Poll::Ready`] on success.
+    /// This method attempts to generate the next ID based on the current time
+    /// and internal state. If successful, it returns [`Poll::Ready`] with a
+    /// newly generated ID. If the generator is temporarily exhausted, it
+    /// returns [`Poll::Pending`]. If an internal failure occurs (e.g., a lock
+    /// error), it returns an error.
     ///
     /// # Returns
     /// - `Ok(Poll::Ready { id })`: A new ID is available
-    /// - `Ok(Poll::Pending { yield_for })`: The time to wait in time-source units
-    ///   before trying again
+    /// - `Ok(Poll::Pending { yield_for })`: The time to wait in time-source
+    ///   units before trying again
     /// - `Err(e)`: the lock was poisoned
     ///
     /// # Example
@@ -248,7 +252,11 @@ where
     ///     match generator.try_poll_id() {
     ///         Ok(Poll::Ready { id }) => break id,
     ///         Ok(Poll::Pending { yield_for }) => {
-    ///             std::thread::sleep(core::time::Duration::from_millis(yield_for.to_u64()));
+    ///             std::thread::sleep(core::time::Duration::from_millis(
+    ///                 yield_for
+    ///                     .to_u64()
+    ///                     .saturating_mul(MonotonicClock::<1>::GRANULARITY_MILLIS),
+    ///             ));
     ///         }
     ///         Err(e) => panic!("Generator error: {}", e),
     ///     }

--- a/crates/ferroid/src/generator/ulid/lock_mono.rs
+++ b/crates/ferroid/src/generator/ulid/lock_mono.rs
@@ -20,12 +20,12 @@ use crate::{
 /// ## Features
 /// - ✅ Thread-safe
 /// - ✅ Probabilistically unique (no coordination required)
-/// - ✅ Time-ordered (monotonically increasing per millisecond)
+/// - ✅ Time-ordered (monotonically increasing per time-source tick)
 ///
 /// ## Recommended When
 /// - You're in a multi-threaded environment
 /// - You need require monotonically increasing IDs (ID generated within the
-///   same millisecond increment a sequence counter)
+///   same time-source tick increment a sequence counter)
 /// - Your target doesn't support atomics.
 ///
 /// ## See Also
@@ -96,7 +96,7 @@ where
     /// point of the generator manually.
     ///
     /// # Parameters
-    /// - `timestamp`: The initial timestamp component (usually in milliseconds)
+    /// - `timestamp`: The initial timestamp component (usually in time-source units)
     /// - `machine_id`: The machine or worker identifier
     /// - `sequence`: The initial sequence number
     /// - `time`: A [`TimeSource`] implementation used to fetch the current time
@@ -228,7 +228,7 @@ where
     ///
     /// # Returns
     /// - `Ok(Poll::Ready { id })`: A new ID is available
-    /// - `Ok(Poll::Pending { yield_for })`: The time to wait (in milliseconds)
+    /// - `Ok(Poll::Pending { yield_for })`: The time to wait in time-source units
     ///   before trying again
     /// - `Err(e)`: the lock was poisoned
     ///

--- a/crates/ferroid/src/generator/ulid/tests.rs
+++ b/crates/ferroid/src/generator/ulid/tests.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     id::{Id, ToU64, ULID, UlidId},
     rand::{RandSource, ThreadRandom},
-    time::{MonotonicClock, TimeSource},
+    time::{MonotonicClock, TimeSource, UNIX_EPOCH},
 };
 
 struct MockTime {
@@ -331,6 +331,14 @@ fn atomic_generator_mono_rollover_test() {
 #[test]
 fn basic_generator_monotonic_clock_random_increments() {
     let clock = MonotonicClock::default();
+    let rand = ThreadRandom;
+    let generator: BasicMonoUlidGenerator<ULID, _, _> = BasicMonoUlidGenerator::new(clock, rand);
+    run_generator_monotonic(&generator);
+}
+
+#[test]
+fn basic_generator_quantized_monotonic_clock_random_increments() {
+    let clock = MonotonicClock::<8>::with_epoch(UNIX_EPOCH);
     let rand = ThreadRandom;
     let generator: BasicMonoUlidGenerator<ULID, _, _> = BasicMonoUlidGenerator::new(clock, rand);
     run_generator_monotonic(&generator);

--- a/crates/ferroid/src/generator/ulid/thread_local.rs
+++ b/crates/ferroid/src/generator/ulid/thread_local.rs
@@ -55,7 +55,7 @@ impl Ulid {
     /// than monotonic generation. If monotonic IDs are acceptable for your use
     /// case, prefer [`Self::new_ulid_mono`] to further reduce collision risk.
     ///
-    /// See: [Collision Probability Analysis] (README).
+    /// See [Collision Probability Analysis] in the README.
     ///
     /// # Example
     /// ```
@@ -76,12 +76,12 @@ impl Ulid {
     /// Generates a new **monotonic** ULID using the thread-local generator.
     ///
     /// Within a given millisecond, IDs are strictly increasing **per thread**
-    /// by incrementing the random component. Across threads, sequences are
-    /// independent (no global ordering).
+    /// by incrementing the random component. Across threads, monotonic streams
+    /// are independent (no global ordering).
     ///
     /// Compared to [`Self::new_ulid`], this typically reduces collision
     /// probability when multiple generators are active (e.g. `N > 1` threads).
-    /// See: [Collision Probability Analysis] (README).
+    /// See [Collision Probability Analysis] in the README.
     ///
     /// If the random space saturates for the current millisecond, the generator
     /// retries using the provided callback.

--- a/crates/ferroid/src/time/interface.rs
+++ b/crates/ferroid/src/time/interface.rs
@@ -20,8 +20,12 @@ pub const MASTODON_EPOCH: Duration = UNIX_EPOCH;
 /// This abstraction allows you to plug in a real system clock, a monotonic
 /// timer, or a mocked time source in tests.
 ///
-/// The timestamp type `T` is generic (typically `u64` or `u128`), and the unit
-/// is expected to be **milliseconds** relative to a configurable origin.
+/// The timestamp type `T` is generic (typically `u64` or `u128`).
+///
+/// By default, one returned time unit corresponds to one real millisecond.
+/// Time sources may override [`GRANULARITY_MILLIS`] to expose coarser clock
+/// quanta while still allowing generic code to recover the real duration of a
+/// single returned unit.
 ///
 /// # Example
 /// ```
@@ -38,6 +42,10 @@ pub const MASTODON_EPOCH: Duration = UNIX_EPOCH;
 /// assert_eq!(time.current_millis(), 1234);
 /// ```
 pub trait TimeSource<T> {
-    /// Returns the current time in milliseconds since the configured epoch.
+    /// The number of real milliseconds represented by one returned time unit.
+    const GRANULARITY_MILLIS: u64 = 1;
+
+    /// Returns the current time since the configured epoch in this source's
+    /// native units.
     fn current_millis(&self) -> T;
 }

--- a/crates/ferroid/src/time/mono_clock.rs
+++ b/crates/ferroid/src/time/mono_clock.rs
@@ -76,20 +76,36 @@ struct SharedTickerInner {
 /// Internally, the clock measures time by capturing `Instant::now()` at
 /// construction and adding to it the duration elapsed since a given epoch
 /// (computed from `SystemTime::now()` at startup).
+///
+/// `N` controls the number of real milliseconds represented by one returned
+/// time unit. `MonotonicClock` and `MonotonicClock<1>` return literal
+/// milliseconds, while `MonotonicClock<8>` returns 8-millisecond ticks.
+///
+/// ```compile_fail
+/// use ferroid::time::{MonotonicClock, UNIX_EPOCH};
+///
+/// let _ = MonotonicClock::<0>::with_epoch(UNIX_EPOCH);
+/// ```
 #[derive(Clone, Debug)]
-pub struct MonotonicClock {
+pub struct MonotonicClock<const N: u64 = 1> {
     inner: Arc<SharedTickerInner>,
     epoch_offset: u64, // in milliseconds
 }
 
-impl Default for MonotonicClock {
+impl Default for MonotonicClock<1> {
     /// Constructs a monotonic clock aligned to the default [`UNIX_EPOCH`].
     fn default() -> Self {
         Self::with_epoch(UNIX_EPOCH)
     }
 }
 
-impl MonotonicClock {
+impl<const N: u64> MonotonicClock<N> {
+    const ASSERT_VALID_GRANULARITY: () = assert!(
+        N > 0,
+        "MonotonicClock granularity must be greater than zero"
+    );
+    pub const GRANULARITY_MILLIS: u64 = N;
+
     /// Constructs a monotonic clock using a custom epoch as the origin (t = 0),
     /// specified in milliseconds since the Unix epoch.
     ///
@@ -103,7 +119,8 @@ impl MonotonicClock {
     ///
     /// On each call to [`current_millis`], the clock returns the current tick
     /// value plus a fixed offset - the precomputed difference between the
-    /// current wall-clock time (`SystemTime::now()`) and the given epoch.
+    /// current wall-clock time (`SystemTime::now()`) and the given epoch. The
+    /// final value is quantized into `N`-millisecond units.
     ///
     /// This design avoids syscalls on the hot path and ensures that time never
     /// goes backward, even if the system clock is adjusted externally.
@@ -122,7 +139,7 @@ impl MonotonicClock {
     /// // use ferroid::TWITTER_EPOCH,
     /// // let now = TWITTER_EPOCH;
     ///
-    /// let clock = MonotonicClock::with_epoch(now);
+    /// let clock = MonotonicClock::<1>::with_epoch(now);
     ///
     /// std::thread::sleep(Duration::from_millis(5));
     ///
@@ -142,6 +159,7 @@ impl MonotonicClock {
     /// [`current_millis`]: TimeSource::current_millis
     #[must_use]
     pub fn with_epoch(epoch: Duration) -> Self {
+        let () = Self::ASSERT_VALID_GRANULARITY;
         let inner = Arc::clone(&GLOBAL_TICKER);
 
         #[allow(clippy::cast_possible_truncation)]
@@ -156,18 +174,54 @@ impl MonotonicClock {
     }
 }
 
-impl TimeSource<u64> for MonotonicClock {
-    /// Returns the number of milliseconds since the configured epoch, based on
-    /// the elapsed monotonic time since construction.
+impl<const N: u64> TimeSource<u64> for MonotonicClock<N> {
+    const GRANULARITY_MILLIS: u64 = Self::GRANULARITY_MILLIS;
+
+    /// Returns the number of `N`-millisecond units since the configured epoch,
+    /// based on the elapsed monotonic time since construction.
     fn current_millis(&self) -> u64 {
-        self.epoch_offset + self.inner.current.load(Ordering::Relaxed)
+        let () = Self::ASSERT_VALID_GRANULARITY;
+        (self.epoch_offset + self.inner.current.load(Ordering::Relaxed)) / N
     }
 }
 
-impl TimeSource<u128> for MonotonicClock {
-    /// Returns the number of milliseconds since the configured epoch, based on
-    /// the elapsed monotonic time since construction.
+impl<const N: u64> TimeSource<u128> for MonotonicClock<N> {
+    const GRANULARITY_MILLIS: u64 = Self::GRANULARITY_MILLIS;
+
+    /// Returns the number of `N`-millisecond units since the configured epoch,
+    /// based on the elapsed monotonic time since construction.
     fn current_millis(&self) -> u128 {
         u128::from(<Self as TimeSource<u64>>::current_millis(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_granularity_stays_in_milliseconds() {
+        let clock = MonotonicClock::default();
+        let _ts: u64 = <MonotonicClock as TimeSource<u64>>::current_millis(&clock);
+        assert_eq!(MonotonicClock::<1>::GRANULARITY_MILLIS, 1);
+        assert_eq!(<MonotonicClock as TimeSource<u64>>::GRANULARITY_MILLIS, 1);
+    }
+
+    #[test]
+    fn quantized_granularity_scales_current_millis() {
+        let millis_clock = MonotonicClock::<1>::with_epoch(UNIX_EPOCH);
+        let quantized_clock = MonotonicClock::<8>::with_epoch(UNIX_EPOCH);
+
+        let lower = <MonotonicClock<1> as TimeSource<u64>>::current_millis(&millis_clock);
+        let quantized = <MonotonicClock<8> as TimeSource<u64>>::current_millis(&quantized_clock);
+        let upper = <MonotonicClock<1> as TimeSource<u64>>::current_millis(&millis_clock);
+
+        assert_eq!(MonotonicClock::<8>::GRANULARITY_MILLIS, 8);
+        assert_eq!(
+            <MonotonicClock<8> as TimeSource<u64>>::GRANULARITY_MILLIS,
+            8
+        );
+        assert!(lower / 8 <= quantized);
+        assert!(quantized <= upper / 8);
     }
 }

--- a/crates/pg-ferroid/Cargo.toml
+++ b/crates/pg-ferroid/Cargo.toml
@@ -34,7 +34,7 @@ pg_test = []
 
 [dependencies]
 pgrx = { workspace = true }
-ferroid = { version = "1.0.2", path = "../ferroid", features = ["ulid", "thread-local", "base32"] }
+ferroid = { version = "2.0.0", path = "../ferroid", features = ["ulid", "thread-local", "base32"] }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]


### PR DESCRIPTION
This refactors `MonotonicClock` to support configurable millisecond granularity via `MonotonicClock<const N: u64 = 1>`, while keeping `MonotonicClock<1>` as the default behavior. The default behavior allows the compiler to optimize away the division by `1` and therefore doesn't affect the performance of the clock.

It also adds `TimeSource::GRANULARITY_MILLIS` so generic code can convert clock units back into real time. Async backoff now scales `yield_for` by the time source granularity, and docs/examples were updated to reflect that `yield_for` is expressed in time-source units rather than always literal milliseconds.

## Notable changes
- `MonotonicClock<const N: u64 = 1>`
- `MonotonicClock::<N>::GRANULARITY_MILLIS`
- `TimeSource::GRANULARITY_MILLIS`
- compile-time guard against `MonotonicClock<0>`
- updated docs/tests for quantized clocks and async backoff behavior

## Breaking change
This changes the public API and trait surface, so it should ship as a major version bump.